### PR TITLE
Expose lower effect in RunContext instances

### DIFF
--- a/core/src/main/scala/tofu/package.scala
+++ b/core/src/main/scala/tofu/package.scala
@@ -2,9 +2,9 @@ import cats.effect.Bracket
 import cats.{ApplicativeError, MonadError}
 
 package object tofu {
-  type HasContext[F[_], C]    = Context[F] { type Ctx    = C }
-  type HasLocal[F[_], C]      = Local[F] { type Ctx      = C }
-  type HasContextRun[F[_], C] = RunContext[F] { type Ctx = C }
+  type HasContext[F[_], C]          = Context[F] { type Ctx    = C }
+  type HasLocal[F[_], C]            = Local[F] { type Ctx      = C }
+  type HasContextRun[F[_], G[_], C] = RunContext[F] { type Ctx = C; type Lower[A] = G[A] }
 
   type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
   type MonadThrow[F[_]]       = MonadError[F, Throwable]

--- a/core/src/main/scala/tofu/syntax/context.scala
+++ b/core/src/main/scala/tofu/syntax/context.scala
@@ -14,7 +14,7 @@ object context {
   def runContext[F[_]] = new RunContextPA[F]
 
   class RunContextPA[F[_]] {
-    def apply[A, C, G[_]](fa: F[A])(ctx: C)(implicit runCtx: RunContext.Aux[F, G, C]): G[A] =
+    def apply[A, C, G[_]](fa: F[A])(ctx: C)(implicit runCtx: HasContextRun[F, G, C]): G[A] =
       runCtx.runContext(fa)(ctx)
   }
 

--- a/core/src/test/scala/tofu/ContextSuite.scala
+++ b/core/src/test/scala/tofu/ContextSuite.scala
@@ -1,0 +1,21 @@
+package tofu
+
+import cats.Applicative
+import cats.data.ReaderT
+
+object ContextSuite {
+  type Ctx = Map[String, String]
+
+  def testInstancesForReaderT[F[_]: Applicative](): Unit = {
+    implicitly[HasContext[ReaderT[F, Ctx, *], Ctx]]
+    implicitly[HasLocal[ReaderT[F, Ctx, *], Ctx]]
+    implicitly[HasContextRun[ReaderT[F, Ctx, *], F, Ctx]]
+    ()
+  }
+
+  def testRunContextSyntax[F[_], G[_], A](fa: F[A])(implicit rc: HasContextRun[F, G, Ctx]): G[A] = {
+    import syntax.context._
+    runContext(fa)(Map.empty[String, String])
+  }
+
+}


### PR DESCRIPTION
This PR is to address 2 issues.

1. `RunContext` instances (namely `ReaderT` instance) don't expose their lower effect in the signature, so that it remains a path-dependent member after `runContext` is invoked.

2. There is a [known issue](https://github.com/scala/bug/issues/10582) in scalac with type aliases and implicit resolution. `Context` uses a mix of `Aux`/`Has***` aliases. It causes errors, if a user requires a constraint via one alias while a syntax extension requires the other. (See the `testRunContextSyntax` test, which would fail without this fix). Using only one set of aliases would be a reasonable solution. Since these aliases are used for parameterization of traits being mixed in companion objects, Aux pattern doesn't work out (causing _illegal cyclic reference involving object_). So I propose using package-level aliases everywhere (and their naming is better). Aux ones me be even dropped now or later.
