### PR TITLE
Add string interpolators for error logging

### DIFF
--- a/logging/structured/src/main/scala/tofu/logging/Loggable.scala
+++ b/logging/structured/src/main/scala/tofu/logging/Loggable.scala
@@ -329,4 +329,13 @@ object LoggedValue {
   }
 
   implicit def loggableToLoggedValue[A](x: A)(implicit loggable: Loggable[A]): LoggedValue = loggable.loggedValue(x)
+
+  def error(cause: Throwable): LoggedThrowable = new LoggedThrowable(cause)
+}
+
+final class LoggedThrowable(cause: Throwable) extends Throwable(cause.getMessage, cause) with LoggedValue {
+  override def toString: String = cause.toString
+
+  def logFields[I, V, @sp(Unit) R, @sp M](input: I)(implicit f: LogRenderer[I, V, R, M]): R =
+    f.addString("stacktrace", cause.getStackTrace.mkString("\n"), input)
 }

--- a/logging/structured/src/main/scala/tofu/logging/Logging.scala
+++ b/logging/structured/src/main/scala/tofu/logging/Logging.scala
@@ -33,8 +33,8 @@ trait LoggingBase[F[_]] {
     write(level, message, values: _*)
 
   /** could be overridden in the implementations, write message about some exception */
-  def writeCause(level: Level, message: String, cause: Throwable): F[Unit] =
-    write(level, message, Logging.errorvalue(cause))
+  @silent def writeCause(level: Level, message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    write(level, message, values: _*)
 
   def trace(message: String, values: LoggedValue*): F[Unit] = write(Trace, message, values: _*)
   def debug(message: String, values: LoggedValue*): F[Unit] = write(Debug, message, values: _*)
@@ -53,11 +53,16 @@ trait LoggingBase[F[_]] {
   def errorWithMarker(message: String, marker: Marker, values: LoggedValue*): F[Unit] =
     writeMarker(Error, message, marker, values: _*)
 
-  def traceCause(message: String, cause: Throwable): F[Unit] = writeCause(Trace, message, cause)
-  def debugCause(message: String, cause: Throwable): F[Unit] = writeCause(Debug, message, cause)
-  def infoCause(message: String, cause: Throwable): F[Unit]  = writeCause(Info, message, cause)
-  def warnCause(message: String, cause: Throwable): F[Unit]  = writeCause(Warn, message, cause)
-  def errorCause(message: String, cause: Throwable): F[Unit] = writeCause(Error, message, cause)
+  def traceCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    writeCause(Trace, message, cause, values: _*)
+  def debugCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    writeCause(Debug, message, cause, values: _*)
+  def infoCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    writeCause(Info, message, cause, values: _*)
+  def warnCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    writeCause(Warn, message, cause, values: _*)
+  def errorCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    writeCause(Error, message, cause, values: _*)
 }
 
 /** Logging marked with Service type*/

--- a/logging/structured/src/main/scala/tofu/logging/impl/ContextLoggingImpl.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/ContextLoggingImpl.scala
@@ -33,14 +33,14 @@ class ContextLoggingImpl[F[_]: Applicative, C: Loggable, Service: ClassTag](cont
   override def errorWithMarker(message: String, marker: Marker, values: LoggedValue*): F[Unit] =
     context.ask(ctx => logger.error(ContextMarker(ctx).addMarker(marker), message, values: _*)).whenA(errorEnabled)
 
-  override def traceCause(message: String, cause: Throwable): F[Unit] =
-    context.ask(ctx => logger.trace(ContextMarker(ctx), message, cause)).whenA(errorEnabled)
-  override def debugCause(message: String, cause: Throwable): F[Unit] =
-    context.ask(ctx => logger.debug(ContextMarker(ctx), message, cause)).whenA(errorEnabled)
-  override def infoCause(message: String, cause: Throwable): F[Unit] =
-    context.ask(ctx => logger.info(ContextMarker(ctx), message, cause)).whenA(errorEnabled)
-  override def warnCause(message: String, cause: Throwable): F[Unit] =
-    context.ask(ctx => logger.error(ContextMarker(ctx), message, cause)).whenA(errorEnabled)
-  override def errorCause(message: String, cause: Throwable): F[Unit] =
-    context.ask(ctx => logger.error(ContextMarker(ctx), message, cause)).whenA(errorEnabled)
+  override def traceCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.ask(ctx => logger.trace(ContextMarker(ctx), message, values :+ cause: _*)).whenA(errorEnabled)
+  override def debugCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.ask(ctx => logger.debug(ContextMarker(ctx), message, values :+ cause: _*)).whenA(errorEnabled)
+  override def infoCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.ask(ctx => logger.info(ContextMarker(ctx), message, values :+ cause: _*)).whenA(errorEnabled)
+  override def warnCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.ask(ctx => logger.error(ContextMarker(ctx), message, values :+ cause: _*)).whenA(errorEnabled)
+  override def errorCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.ask(ctx => logger.error(ContextMarker(ctx), message, values :+ cause: _*)).whenA(errorEnabled)
 }

--- a/logging/structured/src/main/scala/tofu/logging/impl/ContextSyncLoggingImpl.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/ContextSyncLoggingImpl.scala
@@ -41,14 +41,14 @@ class ContextSyncLoggingImpl[F[_], C: Loggable](context: F HasContext C, logger:
       .askF(ctx => F.delay(logger.error(ContextMarker(ctx).addMarker(marker), message, values: _*)))
       .whenA(errorEnabled)
 
-  override def traceCause(message: String, cause: Throwable): F[Unit] =
-    context.askF(ctx => F.delay(logger.trace(ContextMarker(ctx), message, cause))).whenA(errorEnabled)
-  override def debugCause(message: String, cause: Throwable): F[Unit] =
-    context.askF(ctx => F.delay(logger.debug(ContextMarker(ctx), message, cause))).whenA(errorEnabled)
-  override def infoCause(message: String, cause: Throwable): F[Unit] =
-    context.askF(ctx => F.delay(logger.info(ContextMarker(ctx), message, cause))).whenA(errorEnabled)
-  override def warnCause(message: String, cause: Throwable): F[Unit] =
-    context.askF(ctx => F.delay(logger.warn(ContextMarker(ctx), message, cause))).whenA(errorEnabled)
-  override def errorCause(message: String, cause: Throwable): F[Unit] =
-    context.askF(ctx => F.delay(logger.error(ContextMarker(ctx), message, cause))).whenA(errorEnabled)
+  override def traceCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.askF(ctx => F.delay(logger.trace(ContextMarker(ctx), message, values :+ cause: _*))).whenA(errorEnabled)
+  override def debugCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.askF(ctx => F.delay(logger.debug(ContextMarker(ctx), message, values :+ cause: _*))).whenA(errorEnabled)
+  override def infoCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.askF(ctx => F.delay(logger.info(ContextMarker(ctx), message, values :+ cause: _*))).whenA(errorEnabled)
+  override def warnCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.askF(ctx => F.delay(logger.warn(ContextMarker(ctx), message, values :+ cause: _*))).whenA(errorEnabled)
+  override def errorCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    context.askF(ctx => F.delay(logger.error(ContextMarker(ctx), message, values :+ cause: _*))).whenA(errorEnabled)
 }

--- a/logging/structured/src/main/scala/tofu/logging/impl/EmbedLogging.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/EmbedLogging.scala
@@ -12,8 +12,8 @@ class EmbedLogging[F[_]: FlatMap](underlying : F[Logging[F]]) extends Logging[F]
 
   override def writeMarker(level: Logging.Level, message: String, marker: Marker, values: LoggedValue*): F[Unit] =
     underlying.flatMap(_.writeMarker(level, message, marker, values: _*))
-  override def writeCause(level: Logging.Level, message: String, cause: Throwable): F[Unit] =
-    underlying.flatMap(_.writeCause(level, message, cause))
+  override def writeCause(level: Logging.Level, message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    underlying.flatMap(_.writeCause(level, message, cause, values: _*))
   override def trace(message: String, values: LoggedValue*): F[Unit] =
     underlying.flatMap(_.trace(message, values: _*))
   override def debug(message: String, values: LoggedValue*): F[Unit] =
@@ -34,9 +34,14 @@ class EmbedLogging[F[_]: FlatMap](underlying : F[Logging[F]]) extends Logging[F]
     underlying.flatMap(_.warnWithMarker(message, marker, values))
   override def errorWithMarker(message: String, marker: Marker, values: LoggedValue*): F[Unit] =
     underlying.flatMap(_.errorWithMarker(message, marker, values))
-  override def traceCause(message: String, cause: Throwable): F[Unit] = underlying.flatMap(_.traceCause(message, cause))
-  override def debugCause(message: String, cause: Throwable): F[Unit] = underlying.flatMap(_.debugCause(message, cause))
-  override def infoCause(message: String, cause: Throwable): F[Unit]  = underlying.flatMap(_.infoCause(message, cause))
-  override def warnCause(message: String, cause: Throwable): F[Unit]  = underlying.flatMap(_.warnCause(message, cause))
-  override def errorCause(message: String, cause: Throwable): F[Unit] = underlying.flatMap(_.errorCause(message, cause))
+  override def traceCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    underlying.flatMap(_.traceCause(message, cause, values: _*))
+  override def debugCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    underlying.flatMap(_.debugCause(message, cause, values: _*))
+  override def infoCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit]  =
+    underlying.flatMap(_.infoCause(message, cause, values: _*))
+  override def warnCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit]  =
+    underlying.flatMap(_.warnCause(message, cause, values: _*))
+  override def errorCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    underlying.flatMap(_.errorCause(message, cause, values: _*))
 }

--- a/logging/structured/src/main/scala/tofu/logging/impl/LoggingImpl.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/LoggingImpl.scala
@@ -3,7 +3,6 @@ package impl
 
 import org.slf4j.{Logger, Marker}
 import tofu.logging.Logging.{Debug, Error, Info, Level, Trace, Warn}
-import tofu.logging.{LoggedValue, Logging}
 
 abstract class LoggingImpl[F[_]](logger: Logger) extends Logging[F] {
 
@@ -31,12 +30,12 @@ abstract class LoggingImpl[F[_]](logger: Logger) extends Logging[F] {
       case Error => errorWithMarker(message, marker)
     }
 
-  override def writeCause(level: Level, message: String, cause: Throwable): F[Unit] =
+  override def writeCause(level: Level, message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
     level match {
-      case Trace => traceCause(message, cause)
-      case Debug => debugCause(message, cause)
-      case Info  => infoCause(message, cause)
-      case Warn  => warnCause(message, cause)
-      case Error => errorCause(message, cause)
+      case Trace => traceCause(message, cause, values: _*)
+      case Debug => debugCause(message, cause, values: _*)
+      case Info  => infoCause(message, cause, values: _*)
+      case Warn  => warnCause(message, cause, values: _*)
+      case Error => errorCause(message, cause, values: _*)
     }
 }

--- a/logging/structured/src/main/scala/tofu/logging/impl/SyncLogging.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/SyncLogging.scala
@@ -17,14 +17,14 @@ class SyncLogging[F[_]](logger: Logger)(implicit F: Sync[F]) extends LoggingImpl
   override def error(message: String, values: LoggedValue*) =
     F.delay(logger.error(message, values: _*)).whenA(errorEnabled)
 
-  override def errorCause(message: String, cause: Throwable): F[Unit] =
-    F.delay(logger.error(message, cause)).whenA(errorEnabled)
-  override def warnCause(message: String, cause: Throwable): F[Unit] =
-    F.delay(logger.warn(message, cause)).whenA(errorEnabled)
-  override def infoCause(message: String, cause: Throwable): F[Unit] =
-    F.delay(logger.info(message, cause)).whenA(errorEnabled)
-  override def debugCause(message: String, cause: Throwable): F[Unit] =
-    F.delay(logger.debug(message, cause)).whenA(errorEnabled)
-  override def traceCause(message: String, cause: Throwable): F[Unit] =
-    F.delay(logger.trace(message, cause)).whenA(errorEnabled)
+  override def errorCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay(logger.error(message, values :+ cause: _*)).whenA(errorEnabled)
+  override def warnCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay(logger.warn(message, values :+ cause: _*)).whenA(errorEnabled)
+  override def infoCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay(logger.info(message, values :+ cause: _*)).whenA(errorEnabled)
+  override def debugCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay(logger.debug(message, values :+ cause: _*)).whenA(errorEnabled)
+  override def traceCause(message: String, cause: Throwable, values: LoggedValue*): F[Unit] =
+    F.delay(logger.trace(message, values :+ cause: _*)).whenA(errorEnabled)
 }

--- a/logging/structured/src/main/scala/tofu/syntax/loggable.scala
+++ b/logging/structured/src/main/scala/tofu/syntax/loggable.scala
@@ -22,6 +22,17 @@ object logging {
       logging.debug(sctx.s(braces(values.size): _*), values: _*)
     def trace[F[_]](values: LoggedValue*)(implicit logging: LoggingBase[F]): F[Unit] =
       logging.trace(sctx.s(braces(values.size): _*), values: _*)
+
+    def errorCause[F[_]](values: LoggedValue*)(ex: Throwable)(implicit logging: LoggingBase[F]): F[Unit] =
+      logging.errorCause(sctx.s(braces(values.size): _*), ex, values: _*)
+    def warnCause[F[_]](values: LoggedValue*)(ex: Throwable)(implicit logging: LoggingBase[F]): F[Unit] =
+      logging.warnCause(sctx.s(braces(values.size): _*), ex, values: _*)
+    def infoCause[F[_]](values: LoggedValue*)(ex: Throwable)(implicit logging: LoggingBase[F]): F[Unit] =
+      logging.infoCause(sctx.s(braces(values.size): _*), ex, values: _*)
+    def debugCause[F[_]](values: LoggedValue*)(ex: Throwable)(implicit logging: LoggingBase[F]): F[Unit] =
+      logging.debugCause(sctx.s(braces(values.size): _*), ex, values: _*)
+    def traceCause[F[_]](values: LoggedValue*)(ex: Throwable)(implicit logging: LoggingBase[F]): F[Unit] =
+      logging.traceCause(sctx.s(braces(values.size): _*), ex, values: _*)
   }
 
   implicit class LoggingCauseOps(val message: String) extends AnyVal {


### PR DESCRIPTION
As of SLF4J version 1.6.0, it is possible to log an exception along with a parameterized message. This PR adds some interpolators to use that feature.