### PR TITLE
Fix hiding order dependency in Loggable

### DIFF
--- a/logging/structured/src/main/scala/tofu/logging/impl/ContramapLoggable.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/ContramapLoggable.scala
@@ -11,6 +11,5 @@ class ContramapLoggable[A, B](val self: Loggable.Base[A], val f: B => A) extends
     self.putField(f(a), name, input)
   override def logVia(a: B, addParam: (String, Any) => Unit): Unit = self.logVia(f(a), addParam)
   override def logShow(a: B): String                               = self.logShow(f(a))
-  override def loggedValue(a: B): LoggedValue                      = self.loggedValue(f(a))
   override def contramap[C](g: C => B): Loggable[C]                = self.contramap(AndThen(g).andThen(f))
 }

--- a/logging/structured/src/main/scala/tofu/logging/impl/HiddenLoggable.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/HiddenLoggable.scala
@@ -9,5 +9,4 @@ class HiddenLoggable[A](val self: Loggable.Base[A]) extends Loggable[A] {
   def fields[I, V, R, M](a: A, input: I)(implicit receiver: LogRenderer[I, V, R, M]): R = self.fields(a, input)
   def putValue[I, V, R, M](a: A, v: V)(implicit r: LogRenderer[I, V, R, M]): M          = self.putValue(a, v)
   override def logVia(a: A, addParam: (String, Any) => Unit): Unit                      = self.logVia(a, addParam)
-  override def loggedValue(a: A): LoggedValue                                           = self.loggedValue(a)
 }


### PR DESCRIPTION
Bug: Hiding LoggedValue depends on order of Loggable modifiers

For example

```
Loggable.intLoggable.named("responseTime").hide.contramap(_.value)
```
doesn't hide value, but
```
Loggable.intLoggable.hide.named("responseTime").contramap(_.value)
```
does.

This make it independent of modifiers order by removing `loggedValue` overriding in proxies