### PR TITLE
Add traverseKey/traverseKeyFilter operations

### DIFF
--- a/core/src/main/scala/tofu/syntax/traverse.scala
+++ b/core/src/main/scala/tofu/syntax/traverse.scala
@@ -1,0 +1,14 @@
+package tofu.syntax
+
+import cats.{Applicative, Traverse, TraverseFilter}
+import cats.syntax.functor._
+
+object traverse {
+  implicit final class TraverseOps[F[_], A](private val ta: F[A]) extends AnyVal {
+    def traverseKey[G[_]: Applicative, B](f: A => G[B])(implicit T: Traverse[F]): G[F[(A, B)]] =
+      T.traverse(ta)(a => f(a).map((a, _)))
+
+    def traverseKeyFilter[G[_]: Applicative, B](f: A => G[Option[B]])(implicit TF: TraverseFilter[F]): G[F[(A, B)]] =
+      TF.traverseFilter(ta)(a => f(a).map(_.map((a, _))))
+  }
+}


### PR DESCRIPTION
Im not sure how one can achieve following signature from issue: `traverseKey(f: A => F[B]): F[(A, B)]` since Traverse embeds `T[_]` inside `F[_]`, so I did it for `traverseKey(f: A => F[B]): F[T[(A, B)]]`
Resolves #127 