### PR TITLE
Fix the spelling and extend documentation

### DIFF
--- a/docs/hascontext.md
+++ b/docs/hascontext.md
@@ -25,7 +25,7 @@ case class User(id: Int, name: String)
 case class MyEnv(user: User)
 
 // defining an extractor, extractor is a common lens that you can read about
-// in a paragrapth about lenses
+// in a paragraph about lenses
 implicit val extractor: Extract[MyEnv, User] = _.user
       
 def program[F[_]: HasContext[*[_], MyEnv]](implicit u: MyEnv Extract User): F[String] = 
@@ -36,3 +36,39 @@ program[ReaderT[Option, MyEnv, *]].run(MyEnv(User(0, "Tofu"))) //> Some(Tofu): O
 
 ```
 
+A bit more complicated example, that shows lenses usage only in the functions that require them:
+
+```scala mdoc
+import tofu.optics._
+import tofu._
+
+import cats.syntax.apply._
+import cats.instances.option._
+import cats._
+import cats.data.ReaderT
+
+// defining our own Env that stores a User and some related Metadata
+case class User(id: Int, name: String)
+case class Metadata(height: Double, age: Int)
+case class MyEnv(user: User, md: Metadata)
+
+// defining an extractor, extractor is a common lens that you can read about
+// in a paragraph about lenses
+implicit val userExtractor: Extract[MyEnv, User]   = _.user
+implicit val mdExtractor: Extract[MyEnv, Metadata] = _.md
+
+// it is possible to define a program that only has a context
+def program[F[_]: Apply: HasContext[*[_], MyEnv]]: F[String] = 
+  (name[F], age[F]).mapN { (name, age) => s"$name: $age" }
+
+// but all the functions that were called inside a program
+// have on demand and only necessary extractors
+def name[F[_]: HasContext[*[_], MyEnv]](implicit u: MyEnv Extract User): F[String] = 
+  Context[F].extract(u).ask(_.name)
+
+def age[F[_]: HasContext[*[_], MyEnv]](implicit m: MyEnv Extract Metadata): F[Int] = 
+  Context[F].extract(m).ask(_.age)
+
+// ~voilà
+program[ReaderT[Option, MyEnv, *]].run(MyEnv(User(0, "Tofu"), Metadata(60, 18))) //> Some(Tofu: 18): Option[String]
+```


### PR DESCRIPTION
Fix my typo in docs and adds a more extended Context with Extractors usage example.