### PR TITLE
Add Context.const function that lifts value into a Context

### DIFF
--- a/core/src/main/scala/tofu/Context.scala
+++ b/core/src/main/scala/tofu/Context.scala
@@ -23,9 +23,9 @@ object Context extends ContextInstances {
   type Aux[F[_], C] = HasContext[F, C]
 
   def const[F[_]: Applicative, C](c: C): HasContext[F, C] = new Context[F] {
-    def functor: Functor[F] = Functor[F]
     type Ctx = C
-    def context: F[C] = Applicative[F].pure(c)
+    val functor: Functor[F] = Functor[F]
+    val context: F[C]       = Applicative[F].pure(c)
   }
 }
 

--- a/core/src/main/scala/tofu/Context.scala
+++ b/core/src/main/scala/tofu/Context.scala
@@ -21,6 +21,12 @@ trait Context[F[_]] {
 object Context extends ContextInstances {
   def apply[F[_]](implicit ctx: Context[F]): HasContext[F, ctx.Ctx] = ctx
   type Aux[F[_], C] = HasContext[F, C]
+
+  def const[F[_]: Applicative, C](c: C): HasContext[F, C] = new Context[F] {
+    def functor: Functor[F] = Functor[F]
+    type Ctx = C
+    def context: F[C] = Applicative[F].pure(c)
+  }
 }
 
 trait ContextInstances extends LocalInstances[λ[(f[_], g[_], r) => HasContext[f, r]]]

--- a/docs/hascontext.md
+++ b/docs/hascontext.md
@@ -52,8 +52,7 @@ case class User(id: Int, name: String)
 case class Metadata(height: Double, age: Int)
 case class MyEnv(user: User, md: Metadata)
 
-// defining an extractor, extractor is a common lens that you can read about
-// in a paragraph about lenses
+// defining extractors
 implicit val userExtractor: Extract[MyEnv, User]   = _.user
 implicit val mdExtractor: Extract[MyEnv, Metadata] = _.md
 


### PR DESCRIPTION
As an alternative to the [ApplicativeAsk.const](https://github.com/typelevel/cats-mtl/blob/9268fcb1469e53ba601bc765cf7d4f78e0b9e45a/core/src/main/scala/cats/mtl/ApplicativeAsk.scala#L36) from cats-mtl, it can be convenient to have a function that lifts values to the Context.

This idea and the code were brought by @optician