### PR TITLE
Fix logback error in ELKLayout initialization

### DIFF
--- a/concurrent/src/main/scala/tofu/concurrent/impl/FocusedRef.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/impl/FocusedRef.scala
@@ -12,8 +12,8 @@ final case class FocusedRef[F[_]: Functor, A, B](ref: Ref[F, A], focus: Contains
     focus.set(a, next) -> res
   }
 
-  def get: F[B]             = ref.get.map(focus.extract)
-  def set(b: B): F[Unit]    = ref.update(a => focus.set(a, b))
+  def get: F[B]          = ref.get.map(focus.extract)
+  def set(b: B): F[Unit] = ref.update(a => focus.set(a, b))
 
   def update(f: B => B): F[Unit]               = ref.update(focus.update(_, f))
   def modify[X](f: B => (B, X)): F[X]          = ref.modify(focusedMod(f))

--- a/logging/layout/src/main/scala/tofu/logging/ELKLayout.scala
+++ b/logging/layout/src/main/scala/tofu/logging/ELKLayout.scala
@@ -1,14 +1,14 @@
 package tofu
 package logging
 
-import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.CoreConstants.{LINE_SEPARATOR => EOL}
+import ch.qos.logback.core.LayoutBase
 import tofu.logging.ELKLayout.Arguments
 import tofu.logging.logback.EventLoggable
 
 /** logging layout writing JSON receivable by logstash */
-class ELKLayout extends PatternLayout {
+class ELKLayout extends LayoutBase[ILoggingEvent] {
   private var arguments: Arguments = Arguments.Merge
 
   private[this] implicit var eventLoggable: Loggable[ILoggingEvent] = EventLoggable.merge


### PR DESCRIPTION
`ELKLayout` extends `PatternLayout` but doesn't support patterns by design. This leads to an initialization error:
```ERROR in tofu.logging.ELKLayout("null") - Empty or null pattern.```

Change parent class to `LayoutBase`.