### PR TITLE
Fix implicit hiding for Mid

### DIFF
--- a/higherKindCore/src/main/scala/tofu/higherKind/Mid.scala
+++ b/higherKindCore/src/main/scala/tofu/higherKind/Mid.scala
@@ -19,7 +19,7 @@ object Mid extends MidInstances {
     override def point[A]: Mid[F, A] = x => x
   }
 
-  /** when unification falls */
+  /** when unification fails */
   def attach[U[f[_]]: ApplyK, F[_]](up: U[Mid[F, *]])(alg: U[F]): U[F] = up.attach(alg)
 
   implicit final class TofuMidAlgebraSyntax[F[_], U[f[_]]](private val self: U[Mid[F, *]]) extends AnyVal {
@@ -41,13 +41,13 @@ object Mid extends MidInstances {
 
 }
 trait MidInstances extends MidInstances1 {
-  implicit def preMonoidK[F[_]]: MonoidK[Mid[F, *]] = new MidMonoidK[F]
+  implicit def midMonoidK[F[_]]: MonoidK[Mid[F, *]] = new MidMonoidK[F]
 
-  implicit def preAlgebraMonoid[F[_], U[f[_]]: MonoidalK]: Monoid[U[Mid[F, *]]] = new MidAlgebraMonoid[F, U]
+  implicit def midAlgebraMonoid[F[_], U[f[_]]: MonoidalK]: Monoid[U[Mid[F, *]]] = new MidAlgebraMonoid[F, U]
 }
 
 trait MidInstances1 {
-  implicit def preAlgebraMonoid[F[_], U[f[_]]: ApplyK]: Semigroup[U[Mid[F, *]]] = new MidAlgebraSemigroup[F, U]
+  implicit def midAlgebraSemigroup[F[_], U[f[_]]: ApplyK]: Semigroup[U[Mid[F, *]]] = new MidAlgebraSemigroup[F, U]
 }
 
 class MidMonoidK[F[_]] extends MonoidK[Mid[F, *]] {

--- a/higherKindCore/src/main/scala/tofu/higherKind/Post.scala
+++ b/higherKindCore/src/main/scala/tofu/higherKind/Post.scala
@@ -5,9 +5,9 @@ import tofu.syntax.funk.funK
 import tofu.syntax.monadic._
 
 /**
-  * a function [F[_], A] =>> A => F[Unit]
-  * an algebra U[Post[F], A] is an algebra which translates all actions to A => F[Unit]
-  * this is useful to represent actions succeeding main logic
+  * A function `[F[_], A] =>> A => F[Unit]`
+  * An algebra `U[Post[F, *]]` is an algebra which translates all actions to `A => F[Unit]`.
+  * This is useful to represent actions succeeding main logic.
   */
 trait Post[F[_], A] {
   def apply(a: A): F[Unit]
@@ -18,7 +18,7 @@ object Post extends PostInstances {
     override def point[A]: Post[F, A] = _ => F.unit
   }
 
-  /** when unification falls */
+  /** when unification fails */
   def attach[U[f[_]]: ApplyK, F[_]: FlatMap](up: U[Post[F, *]])(alg: U[F]): U[F] = up.attach(alg)
 
   def asMid[F[_]: FlatMap]: Post[F, *] ~> Mid[F, *] = funK(p => fa => fa.flatTap(p(_)))

--- a/higherKindCore/src/main/scala/tofu/higherKind/Pre.scala
+++ b/higherKindCore/src/main/scala/tofu/higherKind/Pre.scala
@@ -6,9 +6,9 @@ import tofu.syntax.funk.funK
 import tofu.syntax.monadic._
 
 /**
-  * newtype for [F[_], A] =>> F[Unit]
-  * an algebra U[Pre[F], A] is an algebra which translates all actions to F[Unit]
-  * this is useful to represent actions preceding main logic
+  * Newtype for `[F[_], A] =>> F[Unit]`.
+  * An algebra `U[Pre[F, *]]` is an algebra which translates all actions to `F[Unit]`.
+  * This is useful to represent actions preceding main logic.
   */
 object Pre extends PreInstances {
   type T[F[_], A] <: Base with PreTag
@@ -28,7 +28,7 @@ object Pre extends PreInstances {
 
   def asMid[F[_]: Apply]: Pre[F, *] ~> Mid[F, *] = funK(p => fa => p.value *> fa)
 
-  /** when unification falls */
+  /** when unification fails */
   def attach[U[f[_]]: ApplyK, F[_]: Apply](up: U[T[F, *]])(alg: U[F]): U[F] = up.attach(alg)
 
   implicit final class TofuPreAlgebraSyntax[F[_], U[f[_]]](private val self: U[T[F, *]]) extends AnyVal {

--- a/higherKindCore/src/test/scala/tofu/higherKind/MidSuite.scala
+++ b/higherKindCore/src/test/scala/tofu/higherKind/MidSuite.scala
@@ -1,0 +1,12 @@
+package tofu.higherKind
+
+import cats.tagless.ApplyK
+import cats.{Monoid, Semigroup}
+
+object MidSuite {
+  def summonMidInstances[F[_], U[_[_]]: ApplyK, W[_[_]]: MonoidalK](): Unit = {
+    implicitly[Semigroup[U[Mid[F, *]]]]
+    implicitly[Monoid[W[Mid[F, *]]]]
+    ()
+  }
+}

--- a/higherKindCore/src/test/scala/tofu/higherKind/MidSuite.scala
+++ b/higherKindCore/src/test/scala/tofu/higherKind/MidSuite.scala
@@ -2,6 +2,7 @@ package tofu.higherKind
 
 import cats.tagless.ApplyK
 import cats.{Monoid, Semigroup}
+import tofu.higherKind.Mid._
 
 object MidSuite {
   def summonMidInstances[F[_], U[_[_]]: ApplyK, W[_[_]]: MonoidalK](): Unit = {


### PR DESCRIPTION
`Semigroup[U[Mid[F, *]]]` was unsummonable (having `ApplyK[U]`) due to a hidden instance.