### PR TITLE
Allow summoning LoggableContext unambiguously

### DIFF
--- a/logging/structured/src/main/scala/tofu/logging/LoggableContext.scala
+++ b/logging/structured/src/main/scala/tofu/logging/LoggableContext.scala
@@ -1,8 +1,6 @@
 package tofu
 package logging
 
-import tofu.Context
-
 /** proof that F has contextual value and it is loggable */
 trait LoggableContext[F[_]] {
   type Ctx
@@ -11,9 +9,9 @@ trait LoggableContext[F[_]] {
 }
 
 object LoggableContext {
-  def of[F[_]](implicit ctx: Context[F]) = new LoggableContextPA[F, ctx.Ctx](ctx)
-  class LoggableContextPA[F[_], C](private val ctx: F HasContext C) extends AnyVal {
-    def instance(implicit ctxLog: Loggable[C]): LoggableContext[F] = new LoggableContext[F] {
+  def of[F[_]] = new LoggableContextPA[F]
+  private[logging] final class LoggableContextPA[F[_]](private val dummy: Boolean = true) extends AnyVal {
+    def instance[C](implicit ctx: F HasContext C, ctxLog: Loggable[C]): LoggableContext[F] = new LoggableContext[F] {
       type Ctx = C
       val loggable: Loggable[C]   = ctxLog
       val context: F HasContext C = ctx

--- a/logging/structured/src/test/scala/tofu/logging/LoggableContextSuite.scala
+++ b/logging/structured/src/test/scala/tofu/logging/LoggableContextSuite.scala
@@ -1,0 +1,17 @@
+package tofu.logging
+
+import tofu.HasContext
+
+object LoggableContextSuite {
+
+  def summonInstance[R: Loggable, F[_]: *[_] HasContext R](): Unit = {
+    LoggableContext.of[F].instance
+    ()
+  }
+
+  def summonInstanceUnambiguously[R1: Loggable, R2: Loggable, F[_]: *[_] HasContext R1: *[_] HasContext R2](): Unit = {
+    LoggableContext.of[F].instance[R1]
+    ()
+  }
+
+}


### PR DESCRIPTION
Current implementation of `LoggableContext` companion with its summoner method doesn't allow resolving ambiguity if there are several `Context[F]` instances in the scope (except for passing the needed instance explicitly).

The new implementation works in the same way as the previous one if there's no ambiguity, but also allows choosing the right context by specifying a type param:
```scala
LoggableContext.of[F].instance
LoggableContext.of[F].instance[C]
```