### PR TITLE
ZIO logging read context from Has, provide embedded Logger

### DIFF
--- a/logging/structured/src/main/scala/tofu/logging/impl/EmptyLoggable.scala
+++ b/logging/structured/src/main/scala/tofu/logging/impl/EmptyLoggable.scala
@@ -1,0 +1,29 @@
+package tofu.logging.impl
+
+import tofu.logging._
+import tofu.syntax.logRenderer._
+
+class EmptyLoggable[A] extends SingleValueLoggable[A] {
+  def logValue(a: A): LogParamValue = NullValue
+  override def putField[I, V, R, M](a: A, name: String, input: I)(implicit receiver: LogRenderer[I, V, R, M]): R =
+    input.noop
+  override def logShow(a: A): String = ""
+
+  override def hide: Loggable[A] = this
+
+  override def +(that: Loggable.Base[A]): Loggable[A] = that.narrow
+
+  override def plus[B <: A](that: Loggable.Base[B]): Loggable.Base[B] = that.narrow
+
+  override def filter(p: A => Boolean): Loggable[A] = this
+
+  override def filterC[B <: A](p: B => Boolean): Loggable.Base[B] = this
+
+  override def contraCollect[B](f: PartialFunction[B, A]): Loggable[B] = EmptyLoggable.narrow[B]
+
+  override def named(name: String): Loggable[A] = this
+
+  override def narrow[B <: A]: EmptyLoggable[B] = this.asInstanceOf[EmptyLoggable[B]]
+}
+
+object EmptyLoggable extends EmptyLoggable[Any]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val catsEffect      = "org.typelevel"              %% "cats-effect"         % Version.catsEffect
   val monix           = "io.monix"                   %% "monix"               % Version.monix
   val logback         = "ch.qos.logback"             % "logback-classic"      % Version.logback
-  val slf4j           = "org.slf4j"                  % "slf4j-simple"         % Version.slf4j % Provided
+  val slf4j           = "org.slf4j"                  % "slf4j-api"            % Version.slf4j % Provided
   val circeCore       = "io.circe"                   %% "circe-core"          % Version.circe
   val circeJava8      = "io.circe"                   %% "circe-java8"         % Version.circe
   val circeDerivation = "io.circe"                   %% "circe-derivation"    % Version.circe

--- a/zio/logging/src/main/scala/tofu/logging/zlogs/ZLogs.scala
+++ b/zio/logging/src/main/scala/tofu/logging/zlogs/ZLogs.scala
@@ -1,11 +1,14 @@
 package tofu.logging.zlogs
 
+import izumi.reflect.Tags.Tag
 import org.slf4j.LoggerFactory
-import tofu.logging.{Loggable, Logging}
 import tofu.logging.Logging.loggerForService
 import tofu.logging.zlogs.impl.{UIOZLogging, URIOZLoggingImpl}
-import zio.UIO
+import tofu.logging.{Loggable, Logging}
+import zio.{Has, UIO, ULayer, ZIO, ZLayer}
+
 import scala.reflect.ClassTag
+import zio.interop.catz._
 
 object ZLogs {
   val uio: ZLogs[Any] = new ZLogs[Any] {
@@ -20,4 +23,15 @@ object ZLogs {
     override def byName(name: String): UIO[ZLogging[R]] =
       UIO.effectTotal(new URIOZLoggingImpl[R](LoggerFactory.getLogger(name)))
   }
+
+  val build = new ZioHasBuilder[Any](Loggable.empty)
+
+  def named[R: Tag](logs: ZLogs[R], name: String): ULayer[ZLog[R]] =
+    ZLayer.fromEffect(logs.byName(name))
+
+  def service[R: Tag, S: ClassTag](logs: ZLogs[R]): ULayer[ZLog[R]] =
+    ZLayer.fromEffect(logs.forService[S])
+
+  def access[R <: ZLog[U] with U: Tag, U <: Has[_]: Tag]: ZLogging[R] =
+    Logging.loggingRepresentable.embed(ZIO.access[ZLog[U]](_.get[ZLogging[U]].widen))
 }

--- a/zio/logging/src/main/scala/tofu/logging/zlogs/ZioHasBuilder.scala
+++ b/zio/logging/src/main/scala/tofu/logging/zlogs/ZioHasBuilder.scala
@@ -1,0 +1,27 @@
+package tofu.logging.zlogs
+
+import izumi.reflect.Tags.Tag
+import tofu.logging.Loggable
+import tofu.logging.zlogs.ZioHasBuilder.UnHas
+import zio.Has
+
+import scala.annotation.implicitNotFound
+
+class ZioHasBuilder[R](val loggable: Loggable[R]) extends AnyVal { self =>
+  def of[U <: Has[_]](implicit U: UnHas[U]) =
+    new ZioHasBuilder[R with U](loggable.narrow[R with U] + U.loggable.narrow[R with U])
+
+  def make[R1 <: R]: ZLogs[R1] = ZLogs.withContext[R1](loggable.narrow[R1])
+}
+
+object ZioHasBuilder {
+  @implicitNotFound(
+    "Could not understand ${U} as zio loggable module. Check it is `Has[SomeService]` and `SomeService` has `Loggable` instance"
+  )
+  class UnHas[U](val loggable: Loggable[U]) extends AnyVal
+
+  object UnHas {
+    implicit def unHas[S: Tag](implicit S: Loggable[S]) =
+      new UnHas[Has[S]](S.contramap(_.get))
+  }
+}

--- a/zio/logging/src/main/scala/tofu/logging/zlogs/package.scala
+++ b/zio/logging/src/main/scala/tofu/logging/zlogs/package.scala
@@ -1,8 +1,11 @@
 package tofu.logging
 
-import zio.{UIO, URIO}
+import zio.{Has, UIO, URIO}
 
 package object zlogs {
   type ZLogs[R]    = Logs[UIO, URIO[R, *]]
   type ZLogging[R] = Logging[URIO[R, *]]
+
+  type ZLog[R] = Has[ZLogging[R]]
+  type ULog    = Has[ZLogging[Any]]
 }

--- a/zio/logging/src/test/scala/tofu/logging/zlogs/ZLogsSuite.scala
+++ b/zio/logging/src/test/scala/tofu/logging/zlogs/ZLogsSuite.scala
@@ -1,0 +1,77 @@
+package tofu.logging.zlogs
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import derevo.derive
+import io.circe.{Json, JsonObject}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.slf4j.LoggerFactory
+import tofu.logging.{LogTree, Loggable}
+import tofu.logging.derivation.loggable
+import tofu.logging.impl.ContextMarker
+import tofu.syntax.logging._
+import zio.blocking.Blocking
+import zio.clock.Clock
+import zio.console.Console
+import zio.{Has, Runtime, URIO, URLayer, ZLayer}
+import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
+
+class ZLogsSuite extends AnyFlatSpec with Matchers {
+  import ZLogsSuite.MyLogging
+
+  val expr = debug"hello" *> info"world"
+
+  "ZLogs" should "log the context" in {
+    val appender = ZLogsSuite.attachList()
+    Runtime.default.unsafeRun(expr.provideLayer(ZLogsSuite.fullLayer))
+    val items = appender.list.asScala
+
+    val expected = JsonObject("foo" -> "kojima".asJson, "bar" -> 2.asJson).asJson
+
+    items.map(_.getMarker).collect {
+      case ContextMarker(ctx, _) => LogTree(ctx)
+    } should ===(List.fill(2)(expected))
+  }
+}
+
+object ZLogsSuite {
+  val Name = "zio logs suite"
+
+  @derive(loggable)
+  case class FooService(foo: String)
+
+  val fooLayer = ZLayer.succeed(FooService("kojima"))
+
+  @derive(loggable)
+  case class BarService(bar: Int)
+
+  val barLayer = ZLayer.succeed(BarService(2))
+
+  type Foo = Has[FooService]
+  type Bar = Has[BarService]
+
+  type LogEnv    = Foo with Bar
+  type SystemEnv = Blocking with Clock with Console
+  type MyEnv     = SystemEnv with LogEnv with ZLog[LogEnv]
+  type TIO[+A]   = URIO[MyEnv, A]
+
+  val logs: ZLogs[Foo with Bar] = ZLogs.build.of[Foo].of[Bar].make
+
+  implicit val MyLogging: ZLogging[MyEnv] = ZLogs.access[MyEnv, LogEnv]
+
+  implicitly[ZioHasBuilder.UnHas[Foo]](ZioHasBuilder.UnHas.unHas[FooService])
+  val fullLayer: URLayer[Blocking with Console with Clock, MyEnv] =
+    ZLayer.identity[SystemEnv] ++ fooLayer ++ barLayer ++ ZLogs.named(logs, Name)
+
+  def attachList() = {
+    val logger   = LoggerFactory.getLogger(Name).asInstanceOf[Logger]
+    val appender = new ListAppender[ILoggingEvent]
+    appender.start()
+    logger.addAppender(appender)
+    appender
+  }
+}


### PR DESCRIPTION
Basically it gives some interop with zio.Has.
One can now easely define set of components, that should be logged during each operation.
Also define an embedded instance `Loggable[URIO[R, *]]` where `R <: Has[Loggable[URIO[R1, *]]` 