### PR TITLE
Fix Daemon cancellation

### DIFF
--- a/concurrent/src/test/scala/tofu/concurrent/DaemonTests.scala
+++ b/concurrent/src/test/scala/tofu/concurrent/DaemonTests.scala
@@ -1,0 +1,28 @@
+package tofu.concurrent
+
+import java.util.concurrent.Executors
+
+import cats.effect.{ContextShift, IO}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import tofu.concurrent.syntax.daemon._
+
+import scala.concurrent.ExecutionContext
+
+class DaemonTests extends AnyWordSpec with Matchers {
+
+  "Daemon" should {
+
+    "not fail when it is cancelled while finishing" in {
+      val ec: ExecutionContext          = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(2))
+      implicit val cs: ContextShift[IO] = IO.contextShift(ec)
+
+      val io = IO.pure(()).daemonize.flatMap(_.cancel)
+      noException shouldBe thrownBy {
+        for { _ <- 1 to 100 } io.unsafeRunSync
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This simple code can fail sometimes with "java.lang.IllegalStateException: Attempting to complete a Deferred that has already been completed" when using cats-effect or monix:
```scala
IO.pure(()).daemonize.flatMap(_.cancel)
```

This happens due to `bracket` implementation in cats-effect and monix which could execute `use` and `release` blocks concurrently.