### PR TITLE
Use forkDaemon instead of fork in zio-interop

### DIFF
--- a/zio/core/src/main/scala/tofu/zioInstances/ZioTofuConcurrentInstance.scala
+++ b/zio/core/src/main/scala/tofu/zioInstances/ZioTofuConcurrentInstance.scala
@@ -25,7 +25,7 @@ class ZioTofuConcurrentInstanceUIO[R, E] extends ZioTofuConcurrentInstance[Any, 
   def agentOf[A](a: A): ZIO[Any, Nothing, Agent[ZIO[R, E, *], A]] = RefM.make(a).map(ZioAgent(_))
 
   def daemonize[A](process: ZIO[R, E, A]): ZIO[R, E, Daemon[ZIO[R, E, *], Cause[E], A]] =
-    process.fork.map(ZIODaemon(_))
+    process.forkDaemon.map(ZIODaemon(_))
 }
 
 final case class ZioDeferred[R, E, A](p: zio.Promise[E, A]) extends Deferred[ZIO[R, E, *], A] {
@@ -65,7 +65,7 @@ final case class ZIODaemon[R, E, A](fib: zio.Fiber[E, A]) extends Daemon[ZIO[R, 
 final case class ZioAgent[R, E, A](refm: RefM[A]) extends Agent[ZIO[R, E, *], A] {
   def get: ZIO[R, E, A]                                                                  = refm.get
   def updateM(f: A => ZIO[R, E, A]): ZIO[R, E, A]                                        = refm.getAndUpdate(f)
-  def fireUpdateM(f: A => ZIO[R, E, A]): ZIO[R, E, Unit]                                 = refm.update(f).fork.unit
+  def fireUpdateM(f: A => ZIO[R, E, A]): ZIO[R, E, Unit]                                 = refm.update(f).forkDaemon.unit
   def modifyM[B](f: A => ZIO[R, E, (B, A)]): ZIO[R, E, B]                                = refm.modify(f)
   def updateSomeM(f: PartialFunction[A, ZIO[R, E, A]]): ZIO[R, E, A]                     = refm.getAndUpdateSome(f)
   def modifySomeM[B](default: B)(f: PartialFunction[A, ZIO[R, E, (B, A)]]): ZIO[R, E, B] = refm.modifySome(default)(f)

--- a/zio/core/src/main/scala/tofu/zioInstances/ZioTofuInstance.scala
+++ b/zio/core/src/main/scala/tofu/zioInstances/ZioTofuInstance.scala
@@ -28,7 +28,7 @@ class ZioTofuInstance[R, E]
     fa.catchSome(CachedMatcher(f))
   final override def handleWith[A](fa: ZIO[R, E, A])(f: E => ZIO[R, E, A]): ZIO[R, E, A] = fa.catchAll(f)
 
-  final def start[A](fa: ZIO[R, E, A]): ZIO[R, E, Fiber[ZIO[R, E, *], A]] = fa.fork.map(convertFiber)
+  final def start[A](fa: ZIO[R, E, A]): ZIO[R, E, Fiber[ZIO[R, E, *], A]] = fa.forkDaemon.map(convertFiber)
   final def racePair[A, B](
       fa: ZIO[R, E, A],
       fb: ZIO[R, E, B]
@@ -40,7 +40,7 @@ class ZioTofuInstance[R, E]
 
   final def race[A, B](fa: ZIO[R, E, A], fb: ZIO[R, E, B]): ZIO[R, E, Either[A, B]] = fa.raceEither(fb)
   final def never[A]: ZIO[R, E, A]                                                  = ZIO.never
-  final def fireAndForget[A](fa: ZIO[R, E, A]): ZIO[R, E, Unit]                     = fa.fork.unit
+  final def fireAndForget[A](fa: ZIO[R, E, A]): ZIO[R, E, Unit]                     = fa.forkDaemon.unit
 
   final def bracket[A, B, C](
       init: ZIO[R, E, A]


### PR DESCRIPTION
Since ZIO 1.0.0-RC18 fibers are garbage collected if their parent fiber terminates. This breaks all "fire and forget" methods and introduces inconsistency with cats-effect and monix backed implementations. Replacing all `fork` calls with `forkDaemon` should return previous behavior.