### PR TITLE
Return from bracketUpdate only on successful update

### DIFF
--- a/core/src/main/scala/tofu/syntax/bracket.scala
+++ b/core/src/main/scala/tofu/syntax/bracket.scala
@@ -38,13 +38,12 @@ object bracket {
   implicit final class TofuBracketMVarOps[F[_], A](private val mvar: MVar[F, A]) extends AnyVal {
 
     /**
-      * Update value with effectful transformation, wait for the new result.
-      * Works similarly to [[tofu.concurrent.Agent.updateM]]
-      * @param use function to atomically modify value contained in `Bracket`
-      * @return `F[A]` modified value contained in `Bracket`
+      * Update value with effectful transformation. In case of error value remains unchanged
+      * @param use function to atomically modify value contained in `MVar`
+      * @return `F[A]` modified value contained in `MVar`
       */
-    def bracketUpdate[B, E](use: A => F[B])(implicit F: Applicative[F], FG: Guarantee[F]): F[B] =
-      mvar.take.bracketOpt(use)((b, isUpdated) => mvar.put(b).whenA(isUpdated))
+    def bracketUpdate[A, E](use: A => F[A])(implicit F: Applicative[F], FG: Guarantee[F]): F[A] =
+      mvar.take.bracketAlways(use)(mvar.put)
   }
 
   implicit final class TofuBracketEitherTOps[F[_], E, A](private val e: EitherT[F, E, A]) extends AnyVal {


### PR DESCRIPTION
Fixes issue #94 
Maybe old behaviour should be preserved and new method should be created with name like `bracketUpdateStrong`