### PR TITLE
Move ConfigTContext.Fail to top of object for initialization issues

### DIFF
--- a/config/src/main/scala/tofu/config/ConfigMonad.scala
+++ b/config/src/main/scala/tofu/config/ConfigMonad.scala
@@ -82,6 +82,8 @@ object ConfigMonad {
 final case class ConfigTContext[F[_]](path: Path, ref: Ref[F, MessageList])
 
 object ConfigTContext {
+  case object Fail extends Exception
+
   implicit def configTParallelConfigMonad[F[_]: ParallelReader](
       implicit F: Monad[F],
       FE: Errors[F, Fail.type]
@@ -110,8 +112,6 @@ object ConfigTContext {
       def lift[A](fa: ConfigT[F, A]): ConfigT[F, A]            = fa
     }
   }
-  case object Fail extends Exception
-
 }
 
 final case class ParallelReader[F[_]](paralleled: Parallel[ConfigT[F, *]]) extends AnyVal


### PR DESCRIPTION
Sometimes, if config is invalid, tofu.config fails with exception:
```
tofu.config.ConfigTContext$Fail$: null
	at tofu.config.ConfigTContext$Fail$.<clinit>(ConfigMonad.scala:113)
	at tofu.config.ConfigTContext$ConfigTConfigMonad$$anon$4.$anonfun$raise$1(ConfigMonad.scala:104)
        ...
```
Probably, it happens, because `case object Fail` in `object ConfigTContext` is used before it is declared. This PR fixes this problem