### PR TITLE
Make Timeout instance for Concurrent types implicit

### DIFF
--- a/core/src/main/scala/tofu/Timeout.scala
+++ b/core/src/main/scala/tofu/Timeout.scala
@@ -4,6 +4,7 @@ import cats.effect.{Concurrent, ContextShift, IO, Timer}
 import simulacrum.typeclass
 import cats.syntax.apply._
 import cats.syntax.functor._
+import tofu.internal.NonTofu
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -13,7 +14,7 @@ trait Timeout[F[_]] {
 }
 
 object Timeout {
-  implicit def concurrent[F[_]](implicit F: Concurrent[F], timer: Timer[F]): Timeout[F] =
+  implicit def concurrent[F[_]](implicit F: Concurrent[F], timer: Timer[F], nonTofu: NonTofu[F]): Timeout[F] =
     new Timeout[F] {
       override def timeoutTo[A](fa: F[A], after: FiniteDuration, fallback: F[A]): F[A] =
         F.race(fa, timer.sleep(after) *> fallback).map(_.merge)

--- a/core/src/main/scala/tofu/Timeout.scala
+++ b/core/src/main/scala/tofu/Timeout.scala
@@ -13,7 +13,7 @@ trait Timeout[F[_]] {
 }
 
 object Timeout {
-  def concurrent[F[_]](implicit F: Concurrent[F], timer: Timer[F]): Timeout[F] =
+  implicit def concurrent[F[_]](implicit F: Concurrent[F], timer: Timer[F]): Timeout[F] =
     new Timeout[F] {
       override def timeoutTo[A](fa: F[A], after: FiniteDuration, fallback: F[A]): F[A] =
         F.race(fa, timer.sleep(after) *> fallback).map(_.merge)


### PR DESCRIPTION
This method is not referenced anywhere and it seems like `implicit` keyword is missing.

Current workaround is to write `implicit val timeoutInstance: Timeout[F] = Timeout.concurrent` and this doesn't look right