### PR TITLE
Use ContravariantRaise instead of Raise in syntax.foption and syntax.feither

### DIFF
--- a/core/src/main/scala/tofu/control/ContravariantFilter.scala
+++ b/core/src/main/scala/tofu/control/ContravariantFilter.scala
@@ -12,5 +12,5 @@ trait ContravariantFilter[F[_]] extends Contravariant[F] with Optional[F] {
   override def optional[A](fa: F[A]): F[Option[A]] = contramapFilter(fa)(identity)
 
   def contraFilter[A](fa: F[A])(f: A => Boolean): F[A] =
-    contramapFilter(fa)(a => if (f(a)) Some(a) else None)
+    contramapFilter(fa)(a => Some(a).filter(f))
 }

--- a/core/src/main/scala/tofu/syntax/foption.scala
+++ b/core/src/main/scala/tofu/syntax/foption.scala
@@ -4,9 +4,9 @@ import cats.{Applicative, Functor, Monad, Traverse}
 import cats.syntax.traverse.toTraverseOps
 import cats.instances.option.catsStdInstancesForOption
 import cats.syntax.option._
-import tofu.Raise
 import tofu.syntax.monadic._
 import tofu.syntax.feither.EitherIdFOps
+import tofu.Raise.ContravariantRaise
 
 object foption {
   def noneF[F[_]: Applicative, A]: F[Option[A]] = none[A].pure[F]
@@ -25,7 +25,7 @@ object foption {
         case x    => x.pure[F]
       }
 
-    def orThrow[E](err: => E)(implicit F: Monad[F], FE: Raise[F, E]): F[A] =
+    def orThrow[E](err: => E)(implicit F: Monad[F], FE: ContravariantRaise[F, E]): F[A] =
       lhs.getOrElseF(FE.raise(err))
 
     def semiflatMap[B](f: A => F[B])(implicit F: Monad[F]): F[Option[B]] =


### PR DESCRIPTION
This allows one to use changed methods with ContravariantRaise in scope only.