### PR TITLE
Add Unlift extensions for summoning (Concurrent)Effect

### DIFF
--- a/core/src/main/scala/tofu/syntax/unlift.scala
+++ b/core/src/main/scala/tofu/syntax/unlift.scala
@@ -6,7 +6,7 @@ import tofu.lift.Unlift
 
 object unlift {
 
-  implicit class UnliftEffectOps[F[_], G[_]](private val U: Unlift[F, G]) extends AnyVal {
+  implicit final class UnliftEffectOps[F[_], G[_]](private val U: Unlift[F, G]) extends AnyVal {
     def effect(implicit G: Functor[G], E: Effect[F]): G[Effect[G]] =
       G.map(U.unlift) { unliftF =>
         new EffectInstance[F, G] {

--- a/core/src/main/scala/tofu/syntax/unlift.scala
+++ b/core/src/main/scala/tofu/syntax/unlift.scala
@@ -47,7 +47,7 @@ object unlift {
 
   }
 
-  trait EffectInstance[F[_], G[_]] extends Effect[G] {
+  private[unlift] trait EffectInstance[F[_], G[_]] extends Effect[G] {
     def toG: F ~> G
     def toF: G ~> F
     implicit def F: Effect[F]
@@ -74,7 +74,7 @@ object unlift {
     def runAsync[A](ga: G[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] = F.runAsync(toF(ga))(cb)
   }
 
-  trait ConcurrentEffectInstance[F[_], G[_]] extends EffectInstance[F, G] with ConcurrentEffect[G] {
+  private[unlift] trait ConcurrentEffectInstance[F[_], G[_]] extends EffectInstance[F, G] with ConcurrentEffect[G] {
     implicit def F: ConcurrentEffect[F]
 
     def start[A](ga: G[A]): G[Fiber[G, A]] = toG(F.map(F.start(toF(ga)))(_.mapK(toG)))

--- a/core/src/main/scala/tofu/syntax/unlift.scala
+++ b/core/src/main/scala/tofu/syntax/unlift.scala
@@ -1,0 +1,92 @@
+package tofu.syntax
+
+import cats.effect.{CancelToken, ConcurrentEffect, Effect, ExitCase, Fiber, IO, SyncIO}
+import cats.{FlatMap, Functor, ~>}
+import tofu.lift.Unlift
+
+object unlift {
+
+  implicit class UnliftEffectOps[F[_], G[_]](private val U: Unlift[F, G]) extends AnyVal {
+    def effect(implicit G: Functor[G], E: Effect[F]): G[Effect[G]] =
+      G.map(U.unlift) { unliftF =>
+        new EffectInstance[F, G] {
+          def toG: F ~> G           = U.liftF
+          def toF: G ~> F           = unliftF
+          implicit def F: Effect[F] = E
+        }
+      }
+
+    def effectWith[A](f: Effect[G] => G[A])(implicit G: FlatMap[G], E: Effect[F]): G[A] =
+      G.flatMap(U.unlift) { unliftF =>
+        val eff = new EffectInstance[F, G] {
+          def toG: F ~> G           = U.liftF
+          def toF: G ~> F           = unliftF
+          implicit def F: Effect[F] = E
+        }
+        f(eff)
+      }
+
+    def concurrentEffect(implicit G: Functor[G], CE: ConcurrentEffect[F]): G[ConcurrentEffect[G]] =
+      G.map(U.unlift) { unliftF =>
+        new ConcurrentEffectInstance[F, G] {
+          def toG: F ~> G                     = U.liftF
+          def toF: G ~> F                     = unliftF
+          implicit def F: ConcurrentEffect[F] = CE
+        }
+      }
+
+    def concurrentEffectWith[A](f: ConcurrentEffect[G] => G[A])(implicit G: FlatMap[G], CE: ConcurrentEffect[F]): G[A] =
+      G.flatMap(U.unlift) { unliftF =>
+        val ce = new ConcurrentEffectInstance[F, G] {
+          def toG: F ~> G                     = U.liftF
+          def toF: G ~> F                     = unliftF
+          implicit def F: ConcurrentEffect[F] = CE
+        }
+        f(ce)
+      }
+
+  }
+
+  trait EffectInstance[F[_], G[_]] extends Effect[G] {
+    def toG: F ~> G
+    def toF: G ~> F
+    implicit def F: Effect[F]
+
+    def pure[A](x: A): G[A] = toG(F.pure(x))
+
+    def flatMap[A, B](ga: G[A])(f: A => G[B]): G[B] = toG(F.flatMap(toF(ga))(a => toF(f(a))))
+
+    def tailRecM[A, B](a: A)(f: A => G[Either[A, B]]): G[B] = toG(F.tailRecM(a)(a => toF(f(a))))
+
+    def raiseError[A](e: Throwable): G[A] = toG(F.raiseError(e))
+
+    def handleErrorWith[A](ga: G[A])(f: Throwable => G[A]): G[A] = toG(F.handleErrorWith(toF(ga))(t => toF(f(t))))
+
+    def bracketCase[A, B](acquire: G[A])(use: A => G[B])(release: (A, ExitCase[Throwable]) => G[Unit]): G[B] =
+      toG(F.bracketCase(toF(acquire))(a => toF(use(a)))((a, e) => toF(release(a, e))))
+
+    def suspend[A](thunk: => G[A]): G[A] = toG(F.suspend(toF(thunk)))
+
+    def async[A](k: (Either[Throwable, A] => Unit) => Unit): G[A] = toG(F.async(k))
+
+    def asyncF[A](k: (Either[Throwable, A] => Unit) => G[Unit]): G[A] = toG(F.asyncF[A](cb => toF(k(cb))))
+
+    def runAsync[A](ga: G[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[Unit] = F.runAsync(toF(ga))(cb)
+  }
+
+  trait ConcurrentEffectInstance[F[_], G[_]] extends EffectInstance[F, G] with ConcurrentEffect[G] {
+    implicit def F: ConcurrentEffect[F]
+
+    def start[A](ga: G[A]): G[Fiber[G, A]] = toG(F.map(F.start(toF(ga)))(_.mapK(toG)))
+
+    def racePair[A, B](ga: G[A], gb: G[B]): G[Either[(A, Fiber[G, B]), (Fiber[G, A], B)]] =
+      toG(F.map(F.racePair(toF(ga), toF(gb))) {
+        case Left((a, fb))  => Left((a, fb.mapK(toG)))
+        case Right((fa, b)) => Right((fa.mapK(toG), b))
+      })
+
+    def runCancelable[A](ga: G[A])(cb: Either[Throwable, A] => IO[Unit]): SyncIO[CancelToken[G]] =
+      F.runCancelable(toF(ga))(cb).map(toG(_))
+  }
+
+}

--- a/core/src/test/scala/tofu/syntax/UnliftSuite.scala
+++ b/core/src/test/scala/tofu/syntax/UnliftSuite.scala
@@ -1,0 +1,26 @@
+package tofu
+
+import cats.Monad
+import cats.effect.{ConcurrentEffect, Effect}
+import tofu.lift.Unlift
+import tofu.syntax.unlift._
+
+object UnliftSuite {
+
+  private def needsEffect[G[_]: Effect]: G[Unit] = Effect[G].unit
+
+  private def needsConcurrentEffect[G[_]: ConcurrentEffect]: G[Unit] = ConcurrentEffect[G].unit
+
+  def checkUnliftEffectSyntax[F[_]: Effect, G[_]: Monad](implicit U: Unlift[F, G]): Unit = {
+    Unlift[F, G].effect: G[Effect[G]]
+    Unlift[F, G].effectWith(implicit E => needsEffect[G])
+    ()
+  }
+
+  def checkUnliftCESyntax[F[_]: ConcurrentEffect, G[_]: Monad](implicit U: Unlift[F, G]): Unit = {
+    Unlift[F, G].concurrentEffect: G[ConcurrentEffect[G]]
+    Unlift[F, G].concurrentEffectWith(implicit CE => needsConcurrentEffect[G])
+    ()
+  }
+
+}


### PR DESCRIPTION
Add some extra methods to `Unlift` as extensions rather than trait members.

This addresses the well-known problem when you need a (Concurrent)Effect instance for a contextual effect, e.g. for integration with impure APIs or poorly designed libs, but you obviously cannot. `Unlift` solves this problem.

Usage:
```scala
Unlift[F, G].concurrentEffectWith { implicit CE => 
  // pretend that you have ConcurrentEffect for G if you have the same for F
  // while staying within the contextual effect G
  needsConcurrentEffect[G]
}
```

The naming and signatures are taken from `zio.interop.catz`.