### PR TITLE
Add Pre syntax for attaching fs2.Stream algebras

### DIFF
--- a/fs2/src/main/scala/tofu/fs2Syntax/pre.scala
+++ b/fs2/src/main/scala/tofu/fs2Syntax/pre.scala
@@ -1,0 +1,13 @@
+package tofu.fs2Syntax
+
+import cats.tagless.ApplyK
+import fs2.Stream
+import tofu.higherKind.Pre.T
+import tofu.syntax.funk.funK
+
+object pre {
+  implicit final class TofuPreStreamSyntax[F[_], U[f[_]]](private val self: U[T[F, *]]) extends AnyVal {
+    def attachStream(alg: U[Stream[F, *]])(implicit U: ApplyK[U]): U[Stream[F, *]] =
+      U.map2K(self, alg)(funK(t2k => Stream.eval_(t2k.first.value) ++ t2k.second))
+  }
+}


### PR DESCRIPTION
Usage:
```scala
import cats.Applicative
import derevo.derive
import fs2.Stream
import tofu.fs2Syntax.pre._
import tofu.higherKind.Pre
import tofu.higherKind.derived.representableK
import tofu.syntax.monadic._

@derive(representableK)
trait StreamingAlg[S[_]] {
  def foo(a: String): S[String]
}

object StreamingAlg {
  def make[F[_] : Applicative]: StreamingAlg[Stream[F, *]] =
    new AuthzPre[F].attachStream(new Impl[F])

  final class Impl[F[_]] extends StreamingAlg[Stream[F, *]] {
    def foo(a: String): Stream[F, String] = Stream.iterate(a)(x => x + x)
  }

  final class AuthzPre[F[_]: Applicative] extends StreamingAlg[Pre[F, *]] {
    def foo(a: String): Pre[F, String] = Pre.apply(unit[F]) // may check privs and rise err
  }

}
```