### PR TITLE
fix RepresentableK macro for traits with vararg parameters in methods

### DIFF
--- a/derivation/src/test/scala/tofu/higherKind/derived/RepresentableKVarArgSuite.scala
+++ b/derivation/src/test/scala/tofu/higherKind/derived/RepresentableKVarArgSuite.scala
@@ -1,0 +1,58 @@
+package tofu.higherKind.derived
+
+import cats.data.Tuple2K
+import cats.effect.IO
+import cats.{Id, ~>}
+import derevo.derive
+import tofu.syntax.funk._
+import tofu.syntax.embed._
+import cats.tagless.syntax.functorK._
+import cats.tagless.syntax.semigroupalK._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import tofu.higherKind.derived.RepresentableKVarArgSuite.Foo
+
+class RepresentableKVarArgSuite extends AnyFlatSpec with Matchers {
+  val ioFoo: Foo[Id] = new Foo[Id] {
+    override def foo(args: Int*): Id[Int] = args.sum
+  }
+
+  val ioTransform: Id ~> Id =  funK(identity)
+
+  "representableK" should "correctly handle varargs with mapK" in {
+    val mappedFoo: Foo[Id] = ioFoo.mapK(ioTransform)
+
+    mappedFoo.foo(1, 2) should === (3)
+    mappedFoo.foo(1)    should === (1)
+    mappedFoo.foo()           should === (0)
+  }
+
+
+  "representableK" should "correctly handle varargs with productK" in {
+    val zippedFoo: Foo[Tuple2K[Id, Id, *]] = ioFoo.productK(ioFoo)
+
+    def tuple[A](a: A): Tuple2K[Id, Id, A] = Tuple2K[Id, Id, A](a, a)
+
+    zippedFoo.foo(1, 2) should === (tuple(3))
+    zippedFoo.foo(1)    should === (tuple(1))
+    zippedFoo.foo()           should === (tuple(0))
+  }
+
+  "representableK" should "correctly handle varargs with embed" in {
+    val foo    : Foo[Id] = ioFoo.asInstanceOf[Id[Foo[Id]]].embed
+
+    foo.foo(1, 2) should === (3)
+    foo.foo(1)    should === (1)
+    foo.foo()           should === (0)
+  }
+
+}
+
+object RepresentableKVarArgSuite {
+
+  @derive(representableK)
+  trait Foo[F[_]]{
+    def foo(args: Int*): F[Int]
+  }
+
+}

--- a/derivation/src/test/scala/tofu/higherKind/derived/RepresentableKVarArgSuite.scala
+++ b/derivation/src/test/scala/tofu/higherKind/derived/RepresentableKVarArgSuite.scala
@@ -17,33 +17,34 @@ class RepresentableKVarArgSuite extends AnyFlatSpec with Matchers {
     override def foo(args: Int*): Id[Int] = args.sum
   }
 
-  val ioTransform: Id ~> Id =  funK(identity)
+  val ioTransform: Id ~> Id = new (Id ~> Id) {
+    override def apply[A](fa: Id[A]): Id[A] = fa
+  }
 
   "representableK" should "correctly handle varargs with mapK" in {
     val mappedFoo: Foo[Id] = ioFoo.mapK(ioTransform)
 
-    mappedFoo.foo(1, 2) should === (3)
-    mappedFoo.foo(1)    should === (1)
-    mappedFoo.foo()           should === (0)
+    mappedFoo.foo(1, 2) should ===(3)
+    mappedFoo.foo(1) should ===(1)
+    mappedFoo.foo() should ===(0)
   }
-
 
   "representableK" should "correctly handle varargs with productK" in {
     val zippedFoo: Foo[Tuple2K[Id, Id, *]] = ioFoo.productK(ioFoo)
 
     def tuple[A](a: A): Tuple2K[Id, Id, A] = Tuple2K[Id, Id, A](a, a)
 
-    zippedFoo.foo(1, 2) should === (tuple(3))
-    zippedFoo.foo(1)    should === (tuple(1))
-    zippedFoo.foo()           should === (tuple(0))
+    zippedFoo.foo(1, 2) should ===(tuple(3))
+    zippedFoo.foo(1) should ===(tuple(1))
+    zippedFoo.foo() should ===(tuple(0))
   }
 
   "representableK" should "correctly handle varargs with embed" in {
-    val foo    : Foo[Id] = ioFoo.asInstanceOf[Id[Foo[Id]]].embed
+    val foo: Foo[Id] = ioFoo.asInstanceOf[Id[Foo[Id]]].embed
 
-    foo.foo(1, 2) should === (3)
-    foo.foo(1)    should === (1)
-    foo.foo()           should === (0)
+    foo.foo(1, 2) should ===(3)
+    foo.foo(1) should ===(1)
+    foo.foo() should ===(0)
   }
 
 }
@@ -51,7 +52,7 @@ class RepresentableKVarArgSuite extends AnyFlatSpec with Matchers {
 object RepresentableKVarArgSuite {
 
   @derive(representableK)
-  trait Foo[F[_]]{
+  trait Foo[F[_]] {
     def foo(args: Int*): F[Int]
   }
 

--- a/higherKindCore/src/main/scala/tofu/higherKind/derived/HigherKindedMacros.scala
+++ b/higherKindCore/src/main/scala/tofu/higherKind/derived/HigherKindedMacros.scala
@@ -32,11 +32,10 @@ class HigherKindedMacros(override val c: blackbox.Context) extends cats.tagless.
   // copied from cats.tagless.DeriveMacros.delegateMethods
   // for correct handling of vararg parameters
   private def methodArgs(method: Method, algebra: Type) =
-    for (ps <- method.signature.paramLists) yield
-      for (p <- ps) yield p.typeSignatureIn(algebra) match {
-        case RepeatedParam(_) => q"${p.name.toTermName}: _*"
-        case _ => Ident(p.name)
-      }
+    for (ps <- method.signature.paramLists) yield for (p <- ps) yield p.typeSignatureIn(algebra) match {
+      case RepeatedParam(_) => q"${p.name.toTermName}: _*"
+      case _                => Ident(p.name)
+    }
 
   private def tabulateTemplate(algebra: Type)(impl: TabulateParams): Type => Tree = {
     case PolyType(List(f), MethodType(List(hom), af)) =>

--- a/higherKindCore/src/main/scala/tofu/higherKind/derived/HigherKindedMacros.scala
+++ b/higherKindCore/src/main/scala/tofu/higherKind/derived/HigherKindedMacros.scala
@@ -29,6 +29,15 @@ class HigherKindedMacros(override val c: blackbox.Context) extends cats.tagless.
       })
   }
 
+  // copied from cats.tagless.DeriveMacros.delegateMethods
+  // for correct handling of vararg parameters
+  private def methodArgs(method: Method, algebra: Type) =
+    for (ps <- method.signature.paramLists) yield
+      for (p <- ps) yield p.typeSignatureIn(algebra) match {
+        case RepeatedParam(_) => q"${p.name.toTermName}: _*"
+        case _ => Ident(p.name)
+      }
+
   private def tabulateTemplate(algebra: Type)(impl: TabulateParams): Type => Tree = {
     case PolyType(List(f), MethodType(List(hom), af)) =>
       val members = overridableMembersOf(af)
@@ -45,12 +54,12 @@ class HigherKindedMacros(override val c: blackbox.Context) extends cats.tagless.
           abort(s"Type parameter $f appears in contravariant position in method ${method.name}")
 
         case method if method.returnType.typeConstructor.typeSymbol == f =>
-          val params = method.paramLists.map(_.map(_.name))
+          val params = methodArgs(method, algebra)
           val body   = q"$hom($repk[$algebra](($algv => $alg.${method.name}(...$params))))"
           method.copy(body = body)
 
         case method if method.occursInReturn(f)                          =>
-          val params = method.paramLists.map(_.map(_.name))
+          val params = methodArgs(method, algebra)
           val tt     = polyType(f :: Nil, method.returnType)
           val tab    = impl.tabMethod(tt)
           val body   =
@@ -65,10 +74,10 @@ class HigherKindedMacros(override val c: blackbox.Context) extends cats.tagless.
       res
   }
 
-  private def embedTemplate(@silent("never used") algebra: Type)(impl: EmbedParams): Type => Tree = {
+  private def embedTemplate(algebra: Type)(impl: EmbedParams): Type => Tree = {
     case PolyType(List(f), MethodType(List(faf), MethodType(List(fmonad), _))) =>
-      def makeMethod(method: Method)(body: List[List[TermName]] => Tree): Method = {
-        val params = method.paramLists.map(_.map(_.name))
+      def makeMethod(method: Method)(body: List[List[Tree]] => Tree): Method = {
+        val params = methodArgs(method, algebra)
         method.copy(body = body(params))
       }
 


### PR DESCRIPTION
with current version this code fails to compile https://scastie.scala-lang.org/iN8saUZZRAC0Vl5x1Ssr4w