### PR TITLE
Make started fibers interruptible in zio-interop

### DIFF
--- a/zio/core/src/main/scala/tofu/zioInstances/ZioTofuConcurrentInstance.scala
+++ b/zio/core/src/main/scala/tofu/zioInstances/ZioTofuConcurrentInstance.scala
@@ -25,7 +25,7 @@ class ZioTofuConcurrentInstanceUIO[R, E] extends ZioTofuConcurrentInstance[Any, 
   def agentOf[A](a: A): ZIO[Any, Nothing, Agent[ZIO[R, E, *], A]] = RefM.make(a).map(ZioAgent(_))
 
   def daemonize[A](process: ZIO[R, E, A]): ZIO[R, E, Daemon[ZIO[R, E, *], Cause[E], A]] =
-    process.forkDaemon.map(ZIODaemon(_))
+    process.interruptible.forkDaemon.map(ZIODaemon(_))
 }
 
 final case class ZioDeferred[R, E, A](p: zio.Promise[E, A]) extends Deferred[ZIO[R, E, *], A] {

--- a/zio/core/src/main/scala/tofu/zioInstances/ZioTofuInstance.scala
+++ b/zio/core/src/main/scala/tofu/zioInstances/ZioTofuInstance.scala
@@ -30,7 +30,9 @@ class ZioTofuInstance[R, E]
     fa.catchSome(CachedMatcher(f))
   final override def handleWith[A](fa: ZIO[R, E, A])(f: E => ZIO[R, E, A]): ZIO[R, E, A]   = fa.catchAll(f)
 
-  final def start[A](fa: ZIO[R, E, A]): ZIO[R, E, Fiber[ZIO[R, E, *], A]]        = fa.forkDaemon.map(convertFiber)
+  final def start[A](fa: ZIO[R, E, A]): ZIO[R, E, Fiber[ZIO[R, E, *], A]] =
+    fa.interruptible.forkDaemon.map(convertFiber)
+
   final def racePair[A, B](
       fa: ZIO[R, E, A],
       fb: ZIO[R, E, B]


### PR DESCRIPTION
This code will never finish with the current implementation:
```scala
ZManaged
  .make(sleep(Duration.Infinity).daemonize)(_.cancel)
  .use(_ => ZIO.succeed(ExitCode.success))
```
Resource acquiring in cats-effect and zio is uncancelable, and zio fibers inherit this property from their parent fiber. Adding `interruptible` should fix this issue, as is done in zio-interop-cats.