### PR TITLE
Additional instances for ContextT and others

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val observable = project.settings(
 )
 
 lazy val concurrent =
-  project dependsOn core settings (
+  project dependsOn (core, data) settings (
     defaultSettings,
     libraryDependencies ++= Seq(catsEffect, catsTagless),
 )
@@ -235,10 +235,10 @@ lazy val doobie      = project
   )
   .dependsOn(core, derivation, env % Test, zioInterop % Test)
 
-lazy val coreModules = Seq(higherKindCore, core, memo, env, concurrent, opticsCore, data)
+lazy val coreModules = Seq(higherKindCore, core, opticsMacro, memo, derivation, env, concurrent, opticsCore, data)
 
 lazy val commonModules =
-  Seq(observable, opticsInterop, opticsMacro, logging, enums, config, derivation, zioInterop, fs2Interop, doobie)
+  Seq(observable, opticsInterop, logging, enums, config, zioInterop, fs2Interop, doobie)
 
 lazy val allModuleRefs = (coreModules ++ commonModules).map(x => x: ProjectReference)
 lazy val allModuleDeps = (coreModules ++ commonModules).map(x => x: ClasspathDep[ProjectReference])
@@ -259,6 +259,7 @@ lazy val docs = project // new documentation project
 lazy val tofu = project
   .in(file("."))
   .settings(defaultSettings)
+  .settings(libraryDependencies += "org.manatki" %% "derevo-cats-tagless" % Version.derevo)
   .aggregate((coreModules ++ commonModules).map(x => x: ProjectReference): _*)
   .dependsOn(coreModules.map(x => x: ClasspathDep[ProjectReference]): _*)
 

--- a/concurrent/src/main/scala/tofu/concurrent/ContextT.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/ContextT.scala
@@ -7,7 +7,16 @@ import tofu.syntax.funk.funKFrom
 import tofu.syntax.monadic._
 
 /** a ReaderT analog, allowing to have context referring resulting type
-  *  for instance you can define ```MyCtx[F[_]](state: Ref[F, Int], k ```
+  *  for instance you can define
+  * {{{
+  *  case class MyCtx[F[_]](state: Ref[F, Int])
+  *
+  *  type MyProcess[+A] = ContextT[IO, MyCtx, A]
+  * }}}
+  *
+  * here MyProcess is equivalent to a function alias
+  * {{{type MyProcess[+A] => Ref[MyProcess, Int] => IO[A]}}}
+  * which would be problematic to define using normal `ReaderT`, `Env` or `ZIO` type constructors
   */
 trait ContextT[F[+_], C[_[_]], +A] {
 

--- a/concurrent/src/main/scala/tofu/concurrent/ContextT.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/ContextT.scala
@@ -2,8 +2,11 @@ package tofu.concurrent
 import cats._
 import cats.effect._
 import cats.tagless.{FunctorK, InvariantK}
-import tofu.HasContextRun
+import tofu.{HasContextRun, WithLocal}
 import tofu.concurrent.impl._
+import tofu.higherKind.Embed
+import tofu.lift.{Rebase, Unlift}
+import tofu.optics.{Contains, Extract}
 import tofu.syntax.funk.{funK, funKFrom}
 import tofu.syntax.monadic._
 
@@ -37,7 +40,7 @@ trait ContextT[F[+_], C[_[_]], +A] { self =>
     cg => f(run(ci.imapK(cg)(gc)(fc)))
 }
 
-object ContextT         extends ContextTInstances {
+object ContextT extends ContextTInstances {
   private def makeLiftF[F[+_], C[_[_]]]: F ~> ContextT[F, C, *] = funKFrom[F](fa => _ => fa)
   private val liftFAny                                          = makeLiftF[Any, Any]
 
@@ -61,14 +64,50 @@ object ContextT         extends ContextTInstances {
 
   /** lift underlying value to contextual */
   def lift[F[+_], C[_[_]], A](fa: F[A]): ContextT[F, C, A] = _ => fa
+
+  def transfer[In[_[_]], Out[_[_]], F[+_]: Monad](c1: In[ContextT[F, In, *]])(implicit
+      l: Out[ContextT[F, Out, *]] Contains In[ContextT[F, Out, *]],
+      rc1: Rebase[In],
+  ): In[ContextT[F, Out, *]] = {
+    class uloi(implicit c2c: Out[ContextT[F, Out, *]]) extends Unlift[ContextT[F, Out, *], ContextT[F, In, *]] {
+      implicit def self                                         = this
+      def lift[A](c2a: ContextT[F, Out, A]): ContextT[F, In, A] =
+        c1c => c2a.run(l.set(c2c, rc1.rebase(c1c)))
+
+      def in2out[A](c1a: ContextT[F, In, A]): ContextT[F, Out, A] =
+        c2c => c1a.run(rc1.rebase(l.get(c2c)))
+
+      def unlift: ContextT[F, In, ContextT[F, In, *] ~> ContextT[F, Out, *]] =
+        _ => funKFrom[ContextT[F, In, *]](in2out).pure[F]
+    }
+
+    implicit def uloi(implicit c2c: Out[ContextT[F, Out, *]]): Unlift[ContextT[F, Out, *], ContextT[F, In, *]] =
+      new uloi
+    implicit def ulio: Unlift[ContextT[F, In, *], ContextT[F, Out, *]]                                         = ul
+
+    object ul extends Unlift[ContextT[F, In, *], ContextT[F, Out, *]] {
+      def lift[A](c1a: ContextT[F, In, A]): ContextT[F, Out, A] =
+        implicit c2c => c1a.run(rc1.rebase(l.get(c2c)))
+
+      def t21[A](c2c: Out[ContextT[F, Out, *]])(c2a: ContextT[F, Out, A]): ContextT[F, In, A] =
+        c1c => c2a.run(l.set(c2c, rc1.rebase(c1c)))
+
+      def unlift: ContextT[F, Out, ContextT[F, Out, *] ~> ContextT[F, In, *]] =
+        c2c => funKFrom[ContextT[F, Out, *]](t21(c2c) _).pure[F]
+    }
+
+    rc1.rebase(c1)
+  }
+
 }
+
 trait ContextTInstances extends ContextTInstancesQ
 
-trait ContextTInstancesZ {
+trait ContextTInstancesZ  { self: ContextTInstances =>
   final implicit def contextTInvariant[F[+_]: Invariant, C[_[_]]]: Invariant[ContextT[F, C, *]] = new ContextTInvariantI
 }
 
-trait ContextTInstancesY {
+trait ContextTInstancesY extends ContextTInstancesZ { self: ContextTInstances =>
   final implicit def contextTFunctor[F[+_]: Functor, C[_[_]]]: Functor[ContextT[F, C, *]] = new ContextTFunctorI
 
   final implicit def contextTInvariantSemigroupal[F[+_]: InvariantSemigroupal, C[_[_]]]
@@ -78,7 +117,7 @@ trait ContextTInstancesY {
     new ContextTSemigroupKI
 }
 
-trait ContextTInstancesX extends ContextTInstancesY {
+trait ContextTInstancesX extends ContextTInstancesY { self: ContextTInstances =>
   final implicit def contextTApply[F[+_]: Apply, C[_[_]]]: Apply[ContextT[F, C, *]]             = new ContextTApplyI
   final implicit def contextTMonoidK[F[+_]: MonoidK, C[_[_]]]: MonoidK[ContextT[F, C, *]]       = new ContextTMonoidKI
   final implicit def contextTcoflatMap[F[+_]: CoflatMap, C[_[_]]]: CoflatMap[ContextT[F, C, *]] = new ContextTCoflatMapI
@@ -87,14 +126,14 @@ trait ContextTInstancesX extends ContextTInstancesY {
       : InvariantMonoidal[ContextT[F, C, *]] = new ContextTInvariantMonoidalI
 }
 
-trait ContextTInstancesW extends ContextTInstancesX {
+trait ContextTInstancesW extends ContextTInstancesX { self: ContextTInstances =>
   final implicit def contextTApplicative[F[+_]: Applicative, C[_[_]]]: Applicative[ContextT[F, C, *]] =
     new ContextTApplicativeI
 
   final implicit def contextTFlatMap[F[+_]: FlatMap, C[_[_]]]: FlatMap[ContextT[F, C, *]] = new ContextTFlatMapI
 }
 
-trait ContextTInstancesV extends ContextTInstancesW {
+trait ContextTInstancesV extends ContextTInstancesW { self: ContextTInstances =>
   final implicit def contextTMonad[F[+_]: Monad, C[_[_]]]: Monad[ContextT[F, C, *]] = new ContextTMonadI
 
   final implicit def contextTAlternative[F[+_]: Alternative, C[_[_]]]: Alternative[ContextT[F, C, *]] =
@@ -105,22 +144,27 @@ trait ContextTInstancesV extends ContextTInstancesW {
     new ContextTApplicativeErrorI
 }
 
-trait ContextTInstancesU extends ContextTInstancesV {
+trait ContextTInstancesU extends ContextTInstancesV { self: ContextTInstances =>
   final implicit def contextTMonadError[F[+_]: MonadError[*[_], E], C[_[_]], E]: MonadError[ContextT[F, C, *], E] =
     new ContextTMonadErrorI
 }
 
-trait ContextTInstancesT extends ContextTInstancesU {
+trait ContextTInstancesT extends ContextTInstancesU { self: ContextTInstances =>
   final implicit def contextTBracket[F[+_]: Bracket[*[_], E], C[_[_]], E]: Bracket[ContextT[F, C, *], E] =
     new ContextTBracketI
 }
 
-trait ContextTInstancesS extends ContextTInstancesT {
+trait ContextTInstancesS extends ContextTInstancesT { self: ContextTInstances =>
+
   final implicit def contextTSync[F[+_]: Sync, C[_[_]]]: Sync[ContextT[F, C, *]]       = new ContextTSyncI
   final implicit def contextTLiftIO[F[+_]: LiftIO, C[_[_]]]: LiftIO[ContextT[F, C, *]] = new ContextTLiftIOI
+
+  final implicit def contextTSubContext[F[+_]: Applicative: Defer, C[_[_]], X](implicit
+      lens: C[ContextT[F, C, *]] Contains X
+  ): WithLocal[ContextT[F, C, *], X] = contextTRunContext[F, C].subcontext(lens)
 }
 
-trait ContextTInstancesR extends ContextTInstancesS {
+trait ContextTInstancesR extends ContextTInstancesS { self: ContextTInstances =>
   final implicit def contextTAsync[F[+_]: Async, C[_[_]]]: Async[ContextT[F, C, *]] = new ContextTAsyncI
 
   final implicit def contextTContext[F[+_]: Applicative, C[_[_]]]: ContextTContext[F, C] =
@@ -130,7 +174,7 @@ trait ContextTInstancesR extends ContextTInstancesS {
     new ContextTNonEmptyParallelI[F, C]
 }
 
-trait ContextTInstancesQ extends ContextTInstancesR {
+trait ContextTInstancesQ extends ContextTInstancesR { self: ContextTInstances =>
   final implicit def contextTConcurrent[F[+_]: Concurrent, C[_[_]]]: Concurrent[ContextT[F, C, *]] =
     new ContextTConcurrentI
 

--- a/concurrent/src/main/scala/tofu/concurrent/impl/contextt.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/impl/contextt.scala
@@ -78,10 +78,7 @@ trait ContextTApply[F[+_], C[+_[_]]]
       ff: ContextT[F, C, (A, B) => Z]
   )(fa: ContextT[F, C, A], fb: ContextT[F, C, B]): ContextT[F, C, Z]          =
     c => ff.run(c).ap2(fa.run(c), fb.run(c))
-  final override def map2Eval[A, B, Z](fa: ContextT[F, C, A], fb: Eval[ContextT[F, C, B]])(
-      f: (A, B) => Z
-  ): Eval[ContextT[F, C, Z]]                                                  =
-    Eval.always(c => fa.run(c).map2Eval(fb.map(_.run(c)))(f).value)
+
   final override def ifA[A](
       fcond: ContextT[F, C, Boolean]
   )(ifTrue: ContextT[F, C, A], ifFalse: ContextT[F, C, A]): ContextT[F, C, A] =

--- a/concurrent/src/main/scala/tofu/concurrent/impl/contextt.scala
+++ b/concurrent/src/main/scala/tofu/concurrent/impl/contextt.scala
@@ -76,7 +76,7 @@ trait ContextTApply[F[+_], C[+_[_]]]
 
   final override def ap2[A, B, Z](
       ff: ContextT[F, C, (A, B) => Z]
-  )(fa: ContextT[F, C, A], fb: ContextT[F, C, B]): ContextT[F, C, Z]          =
+  )(fa: ContextT[F, C, A], fb: ContextT[F, C, B]): ContextT[F, C, Z] =
     c => ff.run(c).ap2(fa.run(c), fb.run(c))
 
   final override def ifA[A](
@@ -331,7 +331,7 @@ final class ContextTRunContextUnsafe[F[+_]: Applicative, C[_[_]]]
 trait ContextTNonEmptyParallel[G[+_], C[_[_]]] extends NonEmptyParallel[ContextT[G, C, *]] {
   val G: NonEmptyParallel[G]
   implicit def invC: InvariantK[C]
-  type F[+A] = ContextT[GF, C, A]
+  type F[+A]  = ContextT[GF, C, A]
   type GF[+A] = G.F[A @uv]
 
   override def apply: Apply[F] = {
@@ -345,7 +345,7 @@ trait ContextTNonEmptyParallel[G[+_], C[_[_]]] extends NonEmptyParallel[ContextT
   }
 
   override def sequential: F ~> ContextT[G, C, *] = funKFrom[F](_.imapK(G.sequential)(G.parallel))
-  override def parallel: ContextT[G, C, +*] ~> F   = funKFrom[ContextT[G, C, +*]](_.imapK[GF](G.parallel)(G.sequential))
+  override def parallel: ContextT[G, C, +*] ~> F  = funKFrom[ContextT[G, C, +*]](_.imapK[GF](G.parallel)(G.sequential))
 }
 
 trait ContextTParallel[G[+_], C[_[_]]] extends ContextTNonEmptyParallel[G, C] with Parallel[ContextT[G, C, *]] {
@@ -380,5 +380,3 @@ final class ContextTParallelI[G[+_], C[_[_]]](implicit val G: Parallel[G], val i
 
   override val parallel: ContextT[G, C, *] ~> F = super.parallel
 }
-
-

--- a/core/src/main/scala/tofu/Errors.scala
+++ b/core/src/main/scala/tofu/Errors.scala
@@ -48,6 +48,8 @@ trait Restore[F[_]] extends RestoreTo[F, F] {
   def restoreWith[A](fa: F[A])(ra: => F[A]): F[A]
 }
 
+object Restore extends ErrorsInstanceChain[λ[(f[_], e) => Restore[f]]]
+
 trait HandleTo[F[_], G[_], E] extends RestoreTo[F, G] {
   def handleWith[A](fa: F[A])(f: E => G[A]): G[A]
 

--- a/core/src/main/scala/tofu/control/impl/SelectiveInstances.scala
+++ b/core/src/main/scala/tofu/control/impl/SelectiveInstances.scala
@@ -26,10 +26,10 @@ class SelectiveOverMonad[F[_]](implicit val F: Monad[F]) extends Selective[F] wi
     if (_) F.pure(None) else F.map(fa)(Some(_))
   }
   override def whens_[A](fb: F[Boolean])(fa: => F[A]): F[Unit]       = F.flatMap(fb) {
-    if (_) F.unit else F.void(fa)
+    if (_) F.void(fa) else F.unit
   }
   override def unlesss_[A](fb: F[Boolean])(fa: => F[A]): F[Unit]     = F.flatMap(fb) {
-    if (_) F.void(fa) else F.unit
+    if (_) F.unit else F.void(fa)
   }
 }
 

--- a/core/src/main/scala/tofu/lift/Rebase.scala
+++ b/core/src/main/scala/tofu/lift/Rebase.scala
@@ -1,0 +1,24 @@
+package tofu.lift
+
+import cats.FlatMap
+import cats.tagless.{FunctorK, InvariantK}
+import tofu.higherKind.Embed
+import tofu.syntax.lift._
+
+trait Rebase[U[_[_]]] {
+  def rebase[F[_], G[_]: FlatMap](uf: U[F])(implicit FG: Unlift[F, G]): U[G]
+}
+
+object Rebase extends LowPriorRebase {
+  def apply[U[_[_]]](implicit instance: Rebase[U]): Rebase[U] = instance
+
+  implicit def byFunctorK[U[_[_]]: FunctorK]: Rebase[U] = new Rebase[U] {
+    def rebase[F[_], G[_]: FlatMap](uf: U[F])(implicit FG: Unlift[F, G]): U[G] = uf.lift
+  }
+}
+
+trait LowPriorRebase {
+  final implicit def byEmbedInvariant[U[_[_]]: Embed: InvariantK]: Rebase[U] = new Rebase[U] {
+    def rebase[F[_], G[_]: FlatMap](uf: U[F])(implicit FG: Unlift[F, G]): U[G] = Embed.of(uf.unlift)
+  }
+}

--- a/core/src/main/scala/tofu/syntax/selective.scala
+++ b/core/src/main/scala/tofu/syntax/selective.scala
@@ -1,6 +1,5 @@
 package tofu.syntax
 
-import cats.syntax.option.none
 import tofu.control.Selective
 
 object selective extends Selective.ToSelectiveOps {

--- a/core/src/main/scala/tofu/syntax/selective.scala
+++ b/core/src/main/scala/tofu/syntax/selective.scala
@@ -1,5 +1,6 @@
 package tofu.syntax
 
+import cats.syntax.option.none
 import tofu.control.Selective
 
 object selective extends Selective.ToSelectiveOps {
@@ -10,5 +11,12 @@ object selective extends Selective.ToSelectiveOps {
 
   implicit final class EitherSelectOps[F[_], A, B](private val fe: F[Either[A, B]]) extends AnyVal {
     def selectAp(ff: F[A => B])(implicit F: Selective[F]): F[B] = F.selectAp(fe)(ff)
+  }
+
+  implicit final class BooleanSelectOps[F[_]](private val fb: F[Boolean]) extends AnyVal {
+    def whens[A](fa: => F[A])(implicit F: Selective[F]): F[Option[A]]   = F.whens(fb)(fa)
+    def unlesss[A](fa: => F[A])(implicit F: Selective[F]): F[Option[A]] = F.unlesss(fb)(fa)
+    def whens_[A](fa: => F[A])(implicit F: Selective[F]): F[Unit]       = F.whens_(fb)(fa)
+    def unlesss_[A](fa: => F[A])(implicit F: Selective[F]): F[Unit]     = F.unlesss_(fb)(fa)
   }
 }

--- a/core/src/test/scala/tofu/syntax/RetrySuite.scala
+++ b/core/src/test/scala/tofu/syntax/RetrySuite.scala
@@ -4,7 +4,7 @@ import cats.Applicative
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import org.scalatest.flatspec.AnyFlatSpec
-import tofu.{Handle, Raise}
+import tofu.{ApplicativeThrow, Errors, Handle, Raise}
 import tofu.syntax.handle._
 import tofu.syntax.raise._
 import cats.syntax.all._
@@ -42,5 +42,14 @@ class RetrySuite extends AnyFlatSpec {
       _       <- runRetry[Err2.type, IO](counter, times)
       state   <- counter.get
     } yield assert(state == 1)).unsafeRunSync()
+  }
+}
+
+class RetryChecks{
+
+  def lol[F[_]: ApplicativeThrow](v: F[Unit]): F[Unit] = {
+    v.retry(3)(implicitly[Errors[F, Throwable]])
+    v.retry(3)
+
   }
 }

--- a/core/src/test/scala/tofu/syntax/RetrySuite.scala
+++ b/core/src/test/scala/tofu/syntax/RetrySuite.scala
@@ -45,7 +45,7 @@ class RetrySuite extends AnyFlatSpec {
   }
 }
 
-class RetryChecks{
+class RetryChecks {
 
   def lol[F[_]: ApplicativeThrow](v: F[Unit]): F[Unit] = {
     v.retry(3)(implicitly[Errors[F, Throwable]])

--- a/data/src/main/scala/tofu/data/calc/CalcMOps.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcMOps.scala
@@ -70,6 +70,7 @@ class CalcMOps[+F[+_, +_], -R, -SI, +SO, +E, +A] { self: CalcM[F, R, SI, SO, E, 
   def handle[A1 >: A](f: E => A1): CalcM[F, R, SI, SO, E, A1] = handleWith(e => CalcM.Pure(f(e)))
 
   def as[B](b: => B): CalcM[F, R, SI, SO, E, B]            = map(_ => b)
+  def void: CalcM[F, R, SI, SO, E, Unit]                   = as_(())
   def as_[B](b: B): CalcM[F, R, SI, SO, E, B]              = map(_ => b)
   def mapError[E1](f: E => E1): CalcM[F, R, SI, SO, E1, A] = handleWith(e => CalcM.raise(f(e)))
 

--- a/data/src/main/scala/tofu/data/calc/CalcRunner.scala
+++ b/data/src/main/scala/tofu/data/calc/CalcRunner.scala
@@ -1,17 +1,24 @@
 package tofu.data.calc
 
+import tofu.data.Nothing2T
+
 trait CalcRunner[-F[+_, +_]] {
   def apply[R, SI, SO, E, A](calc: CalcM[F, R, SI, SO, E, A])(r: R, init: SI): (SO, Either[E, A])
 }
 
-object CalcRunner {
-  implicit val nothingRunner: CalcRunner[Nothing] =
-    new CalcRunner[Nothing] {
-      def apply[R, SI, SO, E, A](calc: CalcM[Nothing, R, SI, SO, E, A])(r: R, init: SI): (SO, Either[E, A]) =
-        calc.step(r, init) match {
-          case wrap: StepResult.Wrap[Nothing, _, _, SO, x, E, m, A] => wrap.inner: Nothing
-          case StepResult.Error(s, err)                             => (s, Left(err))
-          case StepResult.Ok(s, a)                                  => (s, Right(a))
-        }
-    }
+object CalcRunner extends LowPriorRunner {
+  implicit val nothingRunner: CalcRunner[Nothing] = nothing2TRunner
+
+}
+
+trait LowPriorRunner { self: CalcRunner.type =>
+  // scala 2.12 instance for use when Nothing breaks implicit search
+  implicit val nothing2TRunner: CalcRunner[Nothing2T] = new CalcRunner[Nothing] {
+    def apply[R, SI, SO, E, A](calc: CalcM[Nothing, R, SI, SO, E, A])(r: R, init: SI): (SO, Either[E, A]) =
+      calc.step(r, init) match {
+        case wrap: StepResult.Wrap[Nothing, _, _, SO, x, E, m, A] => wrap.inner: Nothing
+        case StepResult.Error(s, err)                             => (s, Left(err))
+        case StepResult.Ok(s, a)                                  => (s, Right(a))
+      }
+  }
 }

--- a/data/src/main/scala/tofu/data/data.scala
+++ b/data/src/main/scala/tofu/data/data.scala
@@ -13,6 +13,7 @@ package object data {
   type Identity[+A]                 = A
   type Nothing1 <: Nothing
   type NothingT[+A]                 = Nothing
+  type Nothing2T[+A, +B]            = Nothing
 
   val CalcM: tofu.data.calc.CalcM.type = tofu.data.calc.CalcM
   val CalcT: tofu.data.calc.CalcT.type = tofu.data.calc.CalcT

--- a/higherKindCore/src/main/scala-2.12/tofu/compat/package.scala
+++ b/higherKindCore/src/main/scala-2.12/tofu/compat/package.scala
@@ -13,4 +13,5 @@ object `package` {
   type unused = scala.annotation.nowarn
 
   type unused212 = scala.annotation.nowarn
+  val LazySeq: Stream.type = Stream
 }

--- a/higherKindCore/src/main/scala-2.13/tofu/compat/package.scala
+++ b/higherKindCore/src/main/scala-2.13/tofu/compat/package.scala
@@ -8,10 +8,10 @@ object `package` {
   type LazySeq[+A]   = LazyList[A]
   type NELazySeq[+A] = NonEmptyLazyList[A]
 
-  val lazySeqInstances = cats.instances.lazyList
-
   // this should be preferred over scala.annotation.unused, since it's tracked by -Wunused:nowarn
   type unused = scala.annotation.nowarn
+  val lazySeqInstances       = cats.instances.lazyList
+  val LazySeq: LazyList.type = LazyList
 }
 
 class uv212 extends StaticAnnotation

--- a/higherKindCore/src/main/scala/tofu/syntax/monadic.scala
+++ b/higherKindCore/src/main/scala/tofu/syntax/monadic.scala
@@ -1,8 +1,6 @@
 package tofu.syntax
 import cats.syntax._
-import cats.{Applicative, Apply, FlatMap, Foldable, Functor, Monad, Semigroupal, Traverse}
-import tofu.compat.LazySeq
-import tofu.compat.lazySeqInstances._
+import cats.{Applicative, Apply, FlatMap, Functor, Monad, Semigroupal}
 
 object monadic extends TupleSemigroupalSyntax with ApplicativeSyntax with MonadSyntax {
   def unit[F[_]](implicit F: Applicative[F]): F[Unit] = F.unit

--- a/higherKindCore/src/main/scala/tofu/syntax/monadic.scala
+++ b/higherKindCore/src/main/scala/tofu/syntax/monadic.scala
@@ -1,6 +1,8 @@
 package tofu.syntax
 import cats.syntax._
-import cats.{Applicative, Apply, FlatMap, Functor, Semigroupal}
+import cats.{Applicative, Apply, FlatMap, Foldable, Functor, Monad, Semigroupal, Traverse}
+import tofu.compat.LazySeq
+import tofu.compat.lazySeqInstances._
 
 object monadic extends TupleSemigroupalSyntax with ApplicativeSyntax with MonadSyntax {
   def unit[F[_]](implicit F: Applicative[F]): F[Unit] = F.unit
@@ -25,7 +27,7 @@ object monadic extends TupleSemigroupalSyntax with ApplicativeSyntax with MonadS
     def <*>(fa: F[A])(implicit F: Apply[F]): F[B] = F.ap(fab)(fa)
   }
 
-  implicit final class TofuApplicativeOps(private val condition: Boolean) extends AnyVal {
+  implicit final class TofuApplicativeBooleanOps(private val condition: Boolean) extends AnyVal {
     def when_[F[_], A](fa: => F[A])(implicit F: Applicative[F]): F[Unit] =
       if (condition) F.void(fa) else F.unit
 
@@ -59,6 +61,8 @@ object monadic extends TupleSemigroupalSyntax with ApplicativeSyntax with MonadS
     def productLEval[B](fb: cats.Eval[F[B]])(implicit F: FlatMap[F]): F[C] = F.productLEval(fa)(fb)
     def mproduct[B](f: C => F[B])(implicit F: FlatMap[F]): F[(C, B)]       = F.mproduct(fa)(f)
     def flatTap[B](f: C => F[B])(implicit F: FlatMap[F]): F[C]             = F.flatTap(fa)(f)
+    def replicateM_(n: Int)(implicit F: Monad[F]): F[Unit]                 =
+      F.tailRecM(n)(k => if (k <= 0) F.pure(Right(())) else F.as(fa, Left(k - 1)))
   }
 
   implicit final def tofuSyntaxApplyOps[F[_], A](fa: F[A]): ApplyOps[F, A]               = new ApplyOps(fa)

--- a/src/test/scala/tofu/concurrent/ContextTRebaseSuite.scala
+++ b/src/test/scala/tofu/concurrent/ContextTRebaseSuite.scala
@@ -1,16 +1,16 @@
 package tofu.concurrent
 
-import cats.{FlatMap, Monad}
 import cats.instances.list._
+import cats.{FlatMap, Monad}
 import derevo.derive
 import derevo.tagless.invariantK
 import org.scalatest.funsuite.AnyFunSuite
 import simulacrum.typeclass
 import tofu.Raise
 import tofu.concurrent.ContextTRebaseSuite.{History, Name, Out, State, outer}
-import tofu.data.ICalcM
 import tofu.data.calc.CalcM
 import tofu.data.derived.ContextEmbed
+import tofu.data.{ICalcM, Nothing2T}
 import tofu.higherKind.derived.{embed, representableK}
 import tofu.lift.{Rebase, Unlift}
 import tofu.optics.macros.{ClassyOptics, GenContains, promote}
@@ -129,7 +129,7 @@ object ContextTRebaseSuite {
       history: List[String] = Nil,
   )
 
-  type Eff[+A] = ICalcM[Nothing, Any, State, String, A]
+  type Eff[+A] = ICalcM[Nothing2T, Any, State, String, A]
 
   type In[+A]  = ContextT[Eff, Inner, A]
   type Out[+A] = ContextT[Eff, Outer, A]

--- a/src/test/scala/tofu/concurrent/ContextTRebaseSuite.scala
+++ b/src/test/scala/tofu/concurrent/ContextTRebaseSuite.scala
@@ -1,0 +1,149 @@
+package tofu.concurrent
+
+import cats.{FlatMap, Monad}
+import cats.instances.list._
+import derevo.derive
+import derevo.tagless.invariantK
+import org.scalatest.funsuite.AnyFunSuite
+import simulacrum.typeclass
+import tofu.Raise
+import tofu.concurrent.ContextTRebaseSuite.{History, Name, Out, State, outer}
+import tofu.data.ICalcM
+import tofu.data.calc.CalcM
+import tofu.data.derived.ContextEmbed
+import tofu.higherKind.derived.{embed, representableK}
+import tofu.lift.{Rebase, Unlift}
+import tofu.optics.macros.{ClassyOptics, GenContains, promote}
+import tofu.syntax.lift._
+import tofu.syntax.monadic._
+import tofu.syntax.raise._
+import tofu.syntax.selective._
+
+class ContextTRebaseSuite extends AnyFunSuite {
+  val count = 100
+
+  val joe       = "joe"
+  val jane      = "jane"
+  val oleg      = "oleg"
+  val inkognito = "inkognito"
+  val name      = "name"
+
+  val initAuth = (List(oleg, joe, jane), List(inkognito, name)).tupled.toSet
+
+  def setName[F[_]: Name: History: Monad](name: String) =
+    History[F].inkognito(Name[F].getName).flatTap(History[F].putHistory) *> Name[F].setName(name)
+
+  def program[F[_]: Name: History: Monad] =
+    (setName[F](joe) *> setName[F](jane)).replicateM_(count) *> History[F].readHistory
+
+  test("big program should accumulate input") {
+    assert(
+      program[Out].run(outer).runUnit(State(auth = initAuth, name = oleg))._2 == Right(
+        List.fill(count - 1)(List(joe, jane)).flatten ++ List(joe, oleg)
+      )
+    )
+  }
+}
+
+object ContextTRebaseSuite {
+  @typeclass
+  @derive(representableK)
+  trait Name[F[_]] {
+    def getName: F[String]
+    def setName(name: String): F[Unit]
+  }
+  object Name extends ContextEmbed[Name]
+
+  @typeclass
+  @derive(representableK)
+  trait Auth[F[_]] {
+    def hasAuth(key: String): F[Boolean]
+    def checkAuth(key: String): F[Unit]
+  }
+
+  object Auth extends ContextEmbed[Auth]
+
+  @typeclass
+  @derive(embed, invariantK)
+  trait History[F[_]] {
+    def readHistory: F[List[String]]
+    def putHistory(s: String): F[Unit]
+    def inkognito[A](actions: F[A]): F[A]
+  }
+  object History extends ContextEmbed[History]
+
+  case class NameImpl[F[_]: Auth: Monad](atom: Atom[F, String]) extends Name[F] {
+    def getName: F[String] = atom.get
+
+    def setName(name: String): F[Unit] =
+      Auth[F].checkAuth("name") *> atom.set(name)
+  }
+
+  type RaiseString[F[_]] = Raise[F, String]
+
+  case class AuthImpl[F[_]: Monad: Name: RaiseString](values: F[Set[(String, String)]]) extends Auth[F] {
+    def hasAuth(key: String): F[Boolean] = for {
+      name      <- Name[F].getName
+      authItems <- values
+    } yield authItems((name, key))
+    def checkAuth(key: String): F[Unit]  =
+      hasAuth(key).unlesss_(Name[F].getName.flatTap(name => s"$name hasn't auth for: $key".raise))
+  }
+
+  case class HistoryImpl[F[_]: Monad: Auth](state: Atom[F, List[String]]) extends History[F] {
+    def readHistory: F[List[String]] = state.get
+
+    def putHistory(s: String): F[Unit] = state.update(s :: _)
+
+    def inkognito[A](actions: F[A]): F[A] = for {
+      _   <- Auth[F].checkAuth("inkognito")
+      old <- state.get
+      _   <- state.set(Nil)
+      a   <- actions
+      _   <- state.set(old)
+    } yield a
+  }
+
+  @ClassyOptics
+  case class Inner[F[_]](
+      name: Name[F],
+      auth: Auth[F],
+  )
+
+  implicit object rebase extends Rebase[Inner] {
+    def rebase[F[_], G[_]: FlatMap](uf: Inner[F])(implicit FG: Unlift[F, G]): Inner[G] = Inner[G](
+      Rebase[Name].rebase(uf.name),
+      Rebase[Auth].rebase(uf.auth)
+    )
+  }
+
+  @ClassyOptics
+  case class Outer[F[_]](
+      @promote inner: Inner[F],
+      history: History[F],
+  )
+
+  case class State(
+      auth: Set[(String, String)] = Set(),
+      name: String = "",
+      history: List[String] = Nil,
+  )
+
+  type Eff[+A] = ICalcM[Nothing, Any, State, String, A]
+
+  type In[+A]  = ContextT[Eff, Inner, A]
+  type Out[+A] = ContextT[Eff, Outer, A]
+
+  val stateIn: Atom[In, State]   = Atom.calcMAtom[Nothing, Any, State, String].lift1[In]
+  val stateOut: Atom[Out, State] = Atom.calcMAtom[Nothing, Any, State, String].lift1[Out]
+
+  val inner = Inner[In](
+    NameImpl[In](stateIn.focused(GenContains[State](_.name))),
+    AuthImpl[In](_ => CalcM.get.map(_.auth))
+  )
+
+  val outer = Outer[Out](
+    ContextT.transfer(inner),
+    HistoryImpl[Out](stateOut.focused(GenContains[State](_.history)))
+  )
+}


### PR DESCRIPTION
Here we introduce a new typeclass `Rebase` which is something in between of `InvariantK` and `FunctorK`
It main goal however - transforming higher kinded case classes serving as contexts, not traits.
Right now it forces user to construct instances manually, but we hope we can deliver automatic derivation later.
