### PR TITLE
Fix docs on logging installation

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,8 +4,7 @@ title: Logging
 ---
 
 ## Installation
-`"ru.tinkoff" %% "tofu" % tofu-version`  
-or as a standalone dependency:   
+Logging are available as a separate project
 `"ru.tinkoff" %% "tofu-logging" % tofu-version`  
 
 ## Preface


### PR DESCRIPTION
I see no logging on my classpath with `libraryDependencies += "ru.tinkoff" %% "tofu" % "0.7.9"`