### PR TITLE
Streams syntax refactoring

### DIFF
--- a/streams/src/main/scala/tofu/syntax/streams/broadcast.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/broadcast.scala
@@ -2,20 +2,21 @@ package tofu.syntax.streams
 
 import tofu.streams.Broadcast
 
-object broadcast {
+private[syntax] final class BroadcastOps[F[_], A](private val fa: F[A]) extends AnyVal {
 
-  implicit final class BroadcastOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def broadcast(processors: F[A] => F[Unit]*)(implicit ev: Broadcast[F]): F[Unit] =
+    ev.broadcast(fa)(processors: _*)
 
-    def broadcast(processors: F[A] => F[Unit]*)(implicit ev: Broadcast[F]): F[Unit] =
-      ev.broadcast(fa)(processors: _*)
+  def broadcast(maxConcurrent: Int)(processor: F[A] => F[Unit])(implicit ev: Broadcast[F]): F[Unit] =
+    ev.broadcast(fa)(List.fill(maxConcurrent)(processor): _*)
 
-    def broadcast(maxConcurrent: Int)(processor: F[A] => F[Unit])(implicit ev: Broadcast[F]): F[Unit] =
-      ev.broadcast(fa)(List.fill(maxConcurrent)(processor): _*)
+  def broadcastThrough[B](processors: F[A] => F[B]*)(implicit ev: Broadcast[F]): F[B] =
+    ev.broadcastThrough(fa)(processors: _*)
 
-    def broadcastThrough[B](processors: F[A] => F[B]*)(implicit ev: Broadcast[F]): F[B] =
-      ev.broadcastThrough(fa)(processors: _*)
+  def broadcastThrough[B](maxConcurrent: Int)(processor: F[A] => F[B])(implicit ev: Broadcast[F]): F[B] =
+    ev.broadcastThrough(fa)(List.fill(maxConcurrent)(processor): _*)
+}
 
-    def broadcastThrough[B](maxConcurrent: Int)(processor: F[A] => F[B])(implicit ev: Broadcast[F]): F[B] =
-      ev.broadcastThrough(fa)(List.fill(maxConcurrent)(processor): _*)
-  }
+private[syntax] trait BroadcastSyntax {
+  implicit def toBroadcastOps[F[_], A](fa: F[A]): BroadcastOps[F, A] = new BroadcastOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/chunks.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/chunks.scala
@@ -2,10 +2,11 @@ package tofu.syntax.streams
 
 import tofu.streams.Chunks
 
-object chunks {
+private[syntax] final class ChunksOps[F[_], C[_], A](fa: F[A])(implicit ch: Chunks[F, C]) {
+  def chunks: F[C[A]]                     = ch.chunks(fa)
+  def mapChunks[B](f: C[A] => C[B]): F[B] = ch.mapChunks(fa)(f)
+}
 
-  implicit final class ChunksOps[F[_], C[_], A](fa: F[A])(implicit ch: Chunks[F, C]) {
-    def chunks: F[C[A]]                     = ch.chunks(fa)
-    def mapChunks[B](f: C[A] => C[B]): F[B] = ch.mapChunks(fa)(f)
-  }
+private[syntax] trait ChunkSyntax {
+  implicit def toChunkOps[F[_], C[_], A](fa: F[A])(implicit ch: Chunks[F, C]): ChunksOps[F, C, A] = new ChunksOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/chunks.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/chunks.scala
@@ -3,7 +3,9 @@ package tofu.syntax.streams
 import tofu.streams.Chunks
 
 private[syntax] final class ChunksOps[F[_], C[_], A](fa: F[A])(implicit ch: Chunks[F, C]) {
+  def cons(ca: C[A]): F[A]                = ch.cons(fa)(ca)
   def chunks: F[C[A]]                     = ch.chunks(fa)
+  def chunksN(n: Int): F[C[A]]            = ch.chunkN(fa)(n)
   def mapChunks[B](f: C[A] => C[B]): F[B] = ch.mapChunks(fa)(f)
 }
 

--- a/streams/src/main/scala/tofu/syntax/streams/combineK.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/combineK.scala
@@ -3,9 +3,10 @@ package tofu.syntax.streams
 import cats.syntax.semigroupk._
 import cats.{Defer, SemigroupK}
 
-object combineK {
+private[syntax] final class CombineKOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def repeat(implicit F: SemigroupK[F], D: Defer[F]): F[A] = fa <+> D.defer(repeat)
+}
 
-  implicit class CombineKOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def repeat(implicit F: SemigroupK[F], D: Defer[F]): F[A] = fa <+> D.defer(repeat)
-  }
+private[syntax] trait CombineKSyntax {
+  implicit def toCombineKOps[F[_], A](fa: F[A]): CombineKOps[F, A] = new CombineKOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/compile.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/compile.scala
@@ -2,11 +2,12 @@ package tofu.syntax.streams
 
 import tofu.streams.{Compile, internal}
 
-object compile {
+private[syntax] final class CompileOps[F[_], G[_], A](private val fa: F[A]) extends AnyVal {
+  def fold[B](init: B)(f: (B, A) => B)(implicit c: Compile[F, G]): G[B]           = c.fold(fa)(init)(f)
+  def drain(implicit c: Compile[F, G]): G[Unit]                                   = c.drain(fa)
+  def to[C[_]](implicit c: Compile[F, G], ev: internal.Factory[A, C[A]]): G[C[A]] = c.to[C, A](fa)
+}
 
-  implicit final class CompileOps[F[_], G[_], A](private val fa: F[A]) extends AnyVal {
-    def fold[B](init: B)(f: (B, A) => B)(implicit c: Compile[F, G]): G[B]           = c.fold(fa)(init)(f)
-    def drain(implicit c: Compile[F, G]): G[Unit]                                   = c.drain(fa)
-    def to[C[_]](implicit c: Compile[F, G], ev: internal.Factory[A, C[A]]): G[C[A]] = c.to[C, A](fa)
-  }
+private[syntax] trait CompileSyntax {
+  implicit def toCompileOps[F[_], G[_], A](fa: F[A]): CompileOps[F, G, A] = new CompileOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/emits.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/emits.scala
@@ -3,11 +3,10 @@ package tofu.syntax.streams
 import cats.Foldable
 import tofu.streams.Emits
 
-object emits {
+private[syntax] final class EmitsPA[F[_]](private val __ : Boolean) extends AnyVal {
+  def apply[C[_], A](as: C[A])(implicit C: Foldable[C], emits: Emits[F]): F[A] = emits.emits(as)
+}
 
+private[syntax] trait EmitsSyntax {
   def emits[F[_]]: EmitsPA[F] = new EmitsPA[F](true)
-
-  private[syntax] final class EmitsPA[F[_]](private val __ : Boolean) extends AnyVal {
-    def apply[C[_], A](as: C[A])(implicit C: Foldable[C], emits: Emits[F]): F[A] = emits.emits(as)
-  }
 }

--- a/streams/src/main/scala/tofu/syntax/streams/evals.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/evals.scala
@@ -5,23 +5,25 @@ import cats.{Foldable, Functor}
 import tofu.lift.Lift
 import tofu.streams.Evals
 
-object evals {
+private[syntax] final class EvalsOps[F[_], G[_], A](private val fa: F[A]) extends AnyVal {
+  def evalMap[B](f: A => G[B])(implicit evals: Evals[F, G]): F[B]                      = evals.evalMap(fa)(f)
+  def evalTap[B](f: A => G[B])(implicit evals: Evals[F, G], functor: Functor[G]): F[A] =
+    evals.evalMap(fa)(a => f(a) as a)
+}
+
+private[syntax] final class EvalPA[F[_]](private val __ : Boolean) extends AnyVal {
+  def apply[G[_], A](ga: G[A])(implicit ev: Lift[G, F]): F[A] = ev.lift(ga)
+}
+
+private[syntax] final class EvalsPA[F[_]](private val __ : Boolean) extends AnyVal {
+  def apply[G[_], C[_]: Foldable, A](gca: G[C[A]])(implicit ev: Evals[F, G]): F[A] = ev.evals(gca)
+}
+
+private[syntax] trait EvalsSyntax {
 
   def eval[F[_]]: EvalPA[F] = new EvalPA[F](true)
 
-  private[syntax] final class EvalPA[F[_]](private val __ : Boolean) extends AnyVal {
-    def apply[G[_], A](ga: G[A])(implicit ev: Lift[G, F]): F[A] = ev.lift(ga)
-  }
-
   def evals[F[_]]: EvalsPA[F] = new EvalsPA[F](true)
 
-  private[syntax] final class EvalsPA[F[_]](private val __ : Boolean) extends AnyVal {
-    def apply[G[_], C[_]: Foldable, A](gca: G[C[A]])(implicit ev: Evals[F, G]): F[A] = ev.evals(gca)
-  }
-
-  implicit final class EvalsOps[F[_], G[_], A](private val fa: F[A]) extends AnyVal {
-    def evalMap[B](f: A => G[B])(implicit evals: Evals[F, G]): F[B]                      = evals.evalMap(fa)(f)
-    def evalTap[B](f: A => G[B])(implicit evals: Evals[F, G], functor: Functor[G]): F[A] =
-      evals.evalMap(fa)(a => f(a) as a)
-  }
+  implicit def toEvalsOps[F[_], G[_], A](fa: F[A]): EvalsOps[F, G, A] = new EvalsOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/filter.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/filter.scala
@@ -2,10 +2,11 @@ package tofu.syntax.streams
 
 import cats.FunctorFilter
 
-object filter {
+private[syntax] final class StreamFilterOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def unNone[A0](implicit ev: A <:< Option[A0], ff: FunctorFilter[F]): F[A0] =
+    ff.collect(ff.functor.map(fa)(ev)) { case Some(a0) => a0 }
+}
 
-  implicit final class StreamFilterOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def unNone[A0](implicit ev: A <:< Option[A0], ff: FunctorFilter[F]): F[A0] =
-      ff.collect(ff.functor.map(fa)(ev)) { case Some(a0) => a0 }
-  }
+private[syntax] trait StreamFilterSyntax {
+  implicit def toStreamFilterOps[F[_], A](fa: F[A]): StreamFilterOps[F, A] = new StreamFilterOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/merge.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/merge.scala
@@ -2,9 +2,10 @@ package tofu.syntax.streams
 
 import tofu.streams.Merge
 
-object merge {
+private[syntax] final class MergeOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def merge(that: F[A])(implicit ev: Merge[F]): F[A] = ev.merge(fa)(that)
+}
 
-  implicit final class MergeOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def merge(that: F[A])(implicit ev: Merge[F]): F[A] = ev.merge(fa)(that)
-  }
+private[syntax] trait MergeSyntax {
+  implicit def toMergeOps[F[_], A](fa: F[A]): MergeOps[F, A] = new MergeOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/pace.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/pace.scala
@@ -4,10 +4,11 @@ import tofu.streams.Pace
 
 import scala.concurrent.duration.FiniteDuration
 
-object pace {
+private[syntax] final class PaceOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def throttled(rate: FiniteDuration)(implicit ev: Pace[F]): F[A] = ev.throttled(fa)(rate)
+  def delay(d: FiniteDuration)(implicit ev: Pace[F]): F[A]        = ev.delay(fa)(d)
+}
 
-  implicit final class PaceOps[F[_], A](private val fa: F[A]) extends AnyVal {
-    def throttled(rate: FiniteDuration)(implicit ev: Pace[F]): F[A] = ev.throttled(fa)(rate)
-    def delay(d: FiniteDuration)(implicit ev: Pace[F]): F[A]        = ev.delay(fa)(d)
-  }
+private[syntax] trait PaceSyntax {
+  implicit def toPaceOps[F[_], A](fa: F[A]): PaceOps[F, A] = new PaceOps(fa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/package.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/package.scala
@@ -1,0 +1,33 @@
+package tofu.syntax
+
+package object streams {
+
+  object broadcast extends BroadcastSyntax
+
+  object chunks extends ChunkSyntax
+
+  object combineK extends CombineKSyntax
+
+  object compile extends CompileSyntax
+
+  object emits extends EmitsSyntax
+
+  object evals extends EvalsSyntax
+
+  object filter extends StreamFilterSyntax
+
+  object merge extends MergeSyntax
+
+  object pace extends PaceSyntax
+
+  object parFlatten extends ParFlattenSyntax
+
+  object region extends RegionSyntax
+
+  object temporal extends TemporalSyntax
+
+  object all
+      extends BroadcastSyntax with ChunkSyntax with CombineKSyntax with CompileSyntax with EmitsSyntax with EvalsSyntax
+      with StreamFilterSyntax with MergeSyntax with PaceSyntax with ParFlattenSyntax with RegionSyntax
+      with TemporalSyntax
+}

--- a/streams/src/main/scala/tofu/syntax/streams/parFlatten.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/parFlatten.scala
@@ -2,10 +2,11 @@ package tofu.syntax.streams
 
 import tofu.streams.ParFlatten
 
-object parFlatten {
+private[syntax] final class ParFlattenOps[F[_], A](private val ffa: F[F[A]]) extends AnyVal {
+  def parFlatten(maxConcurrent: Int)(implicit ev: ParFlatten[F]): F[A] = ev.parFlatten(ffa)(maxConcurrent)
+  def parFlattenUnbounded(implicit ev: ParFlatten[F]): F[A]            = ev.parFlattenUnbounded(ffa)
+}
 
-  implicit final class ParFlattenOps[F[_], A](private val ffa: F[F[A]]) extends AnyVal {
-    def parFlatten(maxConcurrent: Int)(implicit ev: ParFlatten[F]): F[A] = ev.parFlatten(ffa)(maxConcurrent)
-    def parFlattenUnbounded(implicit ev: ParFlatten[F]): F[A]            = ev.parFlattenUnbounded(ffa)
-  }
+private[syntax] trait ParFlattenSyntax {
+  implicit def toParFlattenOps[F[_], A](ffa: F[F[A]]): ParFlattenOps[F, A] = new ParFlattenOps(ffa)
 }

--- a/streams/src/main/scala/tofu/syntax/streams/region.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/region.scala
@@ -2,19 +2,19 @@ package tofu.syntax.streams
 
 import tofu.streams.Region
 
-object region {
+private[syntax] final class RegionPA[F[_]](val __ : Boolean) extends AnyVal {
+  def apply[G[_], Exit, R](open: G[R])(close: R => G[Unit])(implicit F: Region[F, G, Exit]): F[R] =
+    F.region(open)(close)
+}
+
+private[syntax] final class RegionCasePA[F[_]](val __ : Boolean) extends AnyVal {
+  def apply[G[_], Exit, R](open: G[R])(close: (R, Exit) => G[Unit])(implicit F: Region[F, G, Exit]): F[R] =
+    F.regionCase(open)(close)
+}
+
+private[syntax] trait RegionSyntax {
 
   def region[F[_]]: RegionPA[F] = new RegionPA[F](true)
 
-  private[syntax] final class RegionPA[F[_]](val __ : Boolean) extends AnyVal {
-    def apply[G[_], Exit, R](open: G[R])(close: R => G[Unit])(implicit F: Region[F, G, Exit]): F[R] =
-      F.region(open)(close)
-  }
-
   def regionCase[F[_]]: RegionCasePA[F] = new RegionCasePA[F](true)
-
-  private[syntax] final class RegionCasePA[F[_]](val __ : Boolean) extends AnyVal {
-    def apply[G[_], Exit, R](open: G[R])(close: (R, Exit) => G[Unit])(implicit F: Region[F, G, Exit]): F[R] =
-      F.regionCase(open)(close)
-  }
 }

--- a/streams/src/main/scala/tofu/syntax/streams/temporal.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/temporal.scala
@@ -4,9 +4,11 @@ import tofu.streams.Temporal
 
 import scala.concurrent.duration.FiniteDuration
 
-object temporal {
+private[syntax] final class TemporalOps[F[_], C[_], A](fa: F[A])(implicit tmp: Temporal[F, C]) {
+  def groupWithin(n: Int, d: FiniteDuration): F[C[A]] = tmp.groupWithin(fa)(n, d)
+}
 
-  implicit final class TemporalOps[F[_], C[_], A](fa: F[A])(implicit tmp: Temporal[F, C]) {
-    def groupWithin(n: Int, d: FiniteDuration): F[C[A]] = tmp.groupWithin(fa)(n, d)
-  }
+private[syntax] trait TemporalSyntax {
+  implicit def toTemporalOps[F[_], C[_], A](fa: F[A])(implicit tmp: Temporal[F, C]): TemporalOps[F, C, A] =
+    new TemporalOps(fa)
 }


### PR DESCRIPTION
Streams syntax refactored in order to support imports like `import tofu.syntax.streams.all._` along with `import tofu.syntax.streams.<concrete_syntax>._`