### PR TITLE
[WIP] Logging Layout and Marker context integration with Scribe

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,12 +90,21 @@ lazy val loggingLayout = project
   )
   .dependsOn(loggingStr)
 
+lazy val loggingScribe = project
+  .in(file("logging/scribe"))
+  .settings(
+    defaultSettings,
+    libraryDependencies ++= Seq(catsCore, catsEffect, scribe, slf4j),
+    publishName := "logging-scribe"
+  )
+  .dependsOn(loggingStr)
+
 lazy val loggingUtil = project
   .in(file("logging/util"))
   .settings(
     defaultSettings,
     publishName := "logging-util",
-    libraryDependencies += slf4j,
+    libraryDependencies += slf4j
   )
   .dependsOn(loggingStr, concurrent)
 

--- a/logging/scribe/src/main/scala/org/slf4j/impl/StaticLoggerBinder.scala
+++ b/logging/scribe/src/main/scala/org/slf4j/impl/StaticLoggerBinder.scala
@@ -1,0 +1,23 @@
+package org.slf4j.impl
+
+import java.util.concurrent.ConcurrentHashMap
+
+import org.slf4j.{ILoggerFactory, Logger}
+import org.slf4j.spi.LoggerFactoryBinder
+
+import tofu.logging.scribe.internal.ScribeLoggerAdapter
+
+class StaticLoggerBinder private() extends LoggerFactoryBinder {
+  private[this] val Loggers = new ConcurrentHashMap[String, Logger]
+
+  val getLoggerFactory: ILoggerFactory = name => Loggers.computeIfAbsent(
+    if (name.equalsIgnoreCase(Logger.ROOT_LOGGER_NAME)) "" else name,
+    new ScribeLoggerAdapter(_)
+  )
+
+  val getLoggerFactoryClassStr: String = "TofuScribeLoggerFactory"
+}
+
+object StaticLoggerBinder extends StaticLoggerBinder {
+  def getSingleton: StaticLoggerBinder = this
+}

--- a/logging/scribe/src/main/scala/org/slf4j/impl/StaticMDCBinder.scala
+++ b/logging/scribe/src/main/scala/org/slf4j/impl/StaticMDCBinder.scala
@@ -1,0 +1,36 @@
+package org.slf4j.impl
+
+import java.util
+
+import org.slf4j.spi.MDCAdapter
+
+import scribe.MDC
+
+class StaticMDCBinder private() {
+  val getMDCA: MDCAdapter = new MDCAdapter {
+    def put(key: String, value: String): Unit = MDC(key) = value
+
+    def get(key: String): String = MDC.get(key).orNull
+
+    def remove(key: String): Unit = MDC.remove(key)
+
+    def clear(): Unit = MDC.clear()
+
+    def getCopyOfContextMap: util.Map[String, String] = {
+      import scala.jdk.CollectionConverters._
+
+      MDC.map.map { case (k, f) => k -> f() }.asJava
+    }
+
+    def setContextMap(map: util.Map[String, String]): Unit = {
+      clear()
+      map.forEach(put(_, _))
+    }
+  }
+
+  val getMDCAdapterClassStr: String = "TofuScribeMDCAdapter"
+}
+
+object StaticMDCBinder extends StaticMDCBinder {
+  def getSingleton: StaticMDCBinder = this
+}

--- a/logging/scribe/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
+++ b/logging/scribe/src/main/scala/org/slf4j/impl/StaticMarkerBinder.scala
@@ -1,0 +1,15 @@
+package org.slf4j.impl
+
+import org.slf4j.IMarkerFactory
+import org.slf4j.spi.MarkerFactoryBinder
+import org.slf4j.helpers.BasicMarkerFactory
+
+class StaticMarkerBinder private() extends MarkerFactoryBinder {
+  val getMarkerFactory: IMarkerFactory = new BasicMarkerFactory
+
+  val getMarkerFactoryClassStr: String = classOf[BasicMarkerFactory].getName
+}
+
+object StaticMarkerBinder extends StaticMarkerBinder {
+  def getSingleton: StaticMarkerBinder = this
+}

--- a/logging/scribe/src/main/scala/tofu/logging/ELKFormatter.scala
+++ b/logging/scribe/src/main/scala/tofu/logging/ELKFormatter.scala
@@ -1,0 +1,30 @@
+package tofu.logging
+
+import _root_.scribe.LogRecord
+import _root_.scribe.output.{LogOutput, TextOutput}
+import _root_.scribe.format.Formatter
+
+import tofu.logging.ELKFormatter.builder
+import tofu.logging.scribe.RecordLoggable
+
+final case class ELKFormatter(loggable: Loggable[RecordLoggable.LogRecord]) extends Formatter {
+  def format[M](rec: LogRecord[M]): LogOutput =
+    new TextOutput(builder(rec)(loggable.asInstanceOf[Loggable[LogRecord[M]]]))
+}
+
+object ELKFormatter {
+  val MarkersField    = "markers"
+  val TimeStampField  = "@timestamp"
+  val LoggerNameField = "loggerName"
+  val ThreadNameField = "threadName"
+  val LevelField      = "level"
+  val HostNameField   = "hostName"
+  val MessageField    = "message"
+  val MessageIdField  = "messageId"
+  val ExceptionField  = "exception"
+  val StackTraceField = "stackTrace"
+
+  val builder: TethysBuilder = TethysBuilder()
+
+  def merge: ELKFormatter = ELKFormatter(RecordLoggable.merge)
+}

--- a/logging/scribe/src/main/scala/tofu/logging/scribe/RecordLoggable.scala
+++ b/logging/scribe/src/main/scala/tofu/logging/scribe/RecordLoggable.scala
@@ -1,0 +1,103 @@
+package tofu.logging.scribe
+
+import cats.syntax.monoid._
+
+import tofu.logging.{DictLoggable, LogRenderer, Loggable, ToStringLoggable}
+import tofu.logging.ELKFormatter._
+import tofu.logging.scribe.RecordLoggable.LogRecord
+import tofu.syntax.logRenderer._
+
+trait RecordLoggable extends DictLoggable[LogRecord] with ToStringLoggable[LogRecord]
+
+class RecordBuiltInLoggable extends RecordLoggable {
+  import java.time.Instant
+  import scribe.format.FormatBlock
+
+  def fields[I, V, R, S](rec: LogRecord, i: I)(implicit r: LogRenderer[I, V, R, S]): R =
+    i.addString(TimeStampField, Instant.ofEpochMilli(rec.timeStamp).toString) |+|
+    i.addString(LoggerNameField, FormatBlock.Position.format(rec).plainText) |+|
+    i.addString(ThreadNameField, rec.thread.getName) |+|
+    i.addString(LevelField, rec.level.name) |+|
+    i.addString(MessageField, rec.loggable(rec.message.value).plainText.trim)
+}
+
+class RecordMarkerLoggable extends RecordLoggable {
+  import tofu.logging.impl.ContextMarker
+  import tofu.logging.scribe.internal.MarkedOutput
+
+  def fields[I, V, R, S](rec: LogRecord, i: I)(implicit r: LogRenderer[I, V, R, S]): R = rec match {
+    case MarkedOutput(marker, _, _) =>
+      marker match {
+        case ContextMarker(marker, Nil) =>
+          marker.logFields(i)
+        case ContextMarker(marker, rest) =>
+          import tofu.data.PArray
+          import PArray.arrInstance
+
+          val restArr = PArray.fromColl(rest)
+          marker.logFields(i) |+| i.sub(MarkersField)((v: V) => v.foldable(restArr)(_ putString _.getName))
+        case marker =>
+          i.sub(MarkersField)((v: V) => v.list(1)((v, _) => v.putString(marker.getName)))
+      }
+    case _ => i.noop
+  }
+}
+
+class RecordArgumentsLoggable extends RecordLoggable {
+  import tofu.logging.scribe.internal.MarkedOutput
+  import tofu.logging.LoggedValue
+
+  def fields[I, V, R, S](rec: LogRecord, i: I)(implicit r: LogRenderer[I, V, R, S]): R = rec match {
+    case MarkedOutput(_, _, args) if args.nonEmpty =>
+      args.foldLeft(i.noop)((acc, arg) =>
+        acc |+| (arg match {
+          case v: LoggedValue => v.logFields(i)
+          case _              => i.noop
+        })
+      )
+    case _ => i.noop
+  }
+}
+
+class RecordExceptionLoggable extends RecordLoggable {
+  def fields[I, V, R, S](rec: LogRecord, i: I)(implicit r: LogRenderer[I, V, R, S]): R = rec.throwable match {
+    case Some(ex) =>
+      i.addString(ExceptionField, ex.getMessage match {
+        case null => ex.getClass.getName
+        case msg  => s"${ex.getClass.getName}: $msg"
+      }) |+|
+      i.addString(StackTraceField, format(ex.getStackTrace))
+    case _        => i.noop
+  }
+
+  private[this] final def format(trace: Array[StackTraceElement]): String =
+    if (trace.isEmpty) ""
+    else {
+      val builder = new StringBuilder()
+
+      for (elem <- trace) {
+        import elem._
+
+        builder ++= s"\tat $getClassName.$getMethodName("
+        builder ++= (getLineNumber match {
+          case -2         => "Native Method"
+          case n if n > 0 => s"$getFileName:$n"
+          case _          => getFileName
+        })
+        builder ++= ")\n"
+      }
+
+      builder.result()
+    }
+}
+
+object RecordLoggable {
+  type LogRecord = scribe.LogRecord[Any]
+
+  lazy val builtIn: Loggable[LogRecord]   = new RecordBuiltInLoggable
+  lazy val marker: Loggable[LogRecord]    = new RecordMarkerLoggable
+  lazy val arguments: Loggable[LogRecord] = new RecordArgumentsLoggable
+  lazy val exception: Loggable[LogRecord] = new RecordExceptionLoggable
+
+  lazy val merge: Loggable[LogRecord] = builtIn + marker + arguments + exception
+}

--- a/logging/scribe/src/main/scala/tofu/logging/scribe/internal/MarkedOutput.scala
+++ b/logging/scribe/src/main/scala/tofu/logging/scribe/internal/MarkedOutput.scala
@@ -1,0 +1,41 @@
+package tofu.logging.scribe.internal
+
+import org.slf4j.Marker
+
+import scribe.{LogRecord, Loggable}
+import scribe.output.LogOutput
+
+final class MarkedOutput(val marker: Marker, val plainText: String, val args: Array[AnyRef])
+  extends LogOutput with Product3[Marker, String, Array[AnyRef]] {
+
+  def map(f: String => String): LogOutput = MarkedOutput(marker, f(plainText), args)
+
+  def _1: Marker = marker
+  def _2: String = plainText
+  def _3: Array[AnyRef] = args
+
+  def canEqual(that: Any): Boolean = that match {
+    case _: MarkedOutput => true
+    case _               => false
+  }
+}
+
+object MarkedOutput {
+  final type Type = Product3[Marker, String, Array[AnyRef]]
+
+  final def apply(marker: Marker, plainText: String, args: Array[AnyRef]) = new MarkedOutput(marker, plainText, args)
+
+  final def apply(product: Type): MarkedOutput = product match {
+    case out: MarkedOutput => out
+    case t                 => apply(t._1, t._2, t._3)
+  }
+
+  final def unapply(rec: LogRecord[Any]): Option[Type] = rec.loggable match {
+    case lg: NonBoxingLoggable.type => Some(lg(rec.message.value).asInstanceOf[MarkedOutput])
+    case _                          => None
+  }
+
+  object NonBoxingLoggable extends Loggable[Type] {
+    def apply(value: Type): LogOutput = MarkedOutput(value)
+  }
+}

--- a/logging/scribe/src/main/scala/tofu/logging/scribe/internal/ScribeLoggerAdapter.scala
+++ b/logging/scribe/src/main/scala/tofu/logging/scribe/internal/ScribeLoggerAdapter.scala
@@ -1,0 +1,197 @@
+package tofu.logging.scribe.internal
+
+import org.slf4j.helpers.FormattingTuple
+import org.slf4j.helpers.MessageFormatter.{arrayFormat => arrFmt, format => fmt}
+import org.slf4j.{Logger, Marker}
+
+import scribe.Level._
+import scribe.{LazyMessage, Level, LogRecord, Logger => ScribeLogger}
+
+class ScribeLoggerAdapter(name: String) extends Logger {
+  def getName: String = name
+
+
+  def isTraceEnabled: Boolean = includes(Trace)
+
+  def isTraceEnabled(marker: Marker): Boolean = isTraceEnabled
+
+  def trace(msg: String): Unit = log(Trace, msg, None)
+
+  def trace(format: String, arg: Any): Unit = log(Trace, fmt(format, arg))
+
+  def trace(format: String, arg1: Any, arg2: Any): Unit = log(Trace, fmt(format, arg1, arg2))
+
+  def trace(format: String, args: AnyRef*): Unit = log(Trace, arrFmt(format, args.toArray))
+
+  def trace(msg: String, err: Throwable): Unit = log(Trace, msg, Option(err))
+
+  def trace(marker: Marker, msg: String): Unit = log(marker, Trace, msg)
+
+  def trace(marker: Marker, msg: String, err: Throwable): Unit = log(marker, Trace, msg, err = Option(err))
+
+  def trace(marker: Marker, format: String, arg: Any): Unit =
+    log(marker, Trace, fmt(format, arg))
+
+  def trace(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+    log(marker, Trace, fmt(format, arg1, arg2))
+
+  def trace(marker: Marker, format: String, args: AnyRef*): Unit =
+    log(marker, Trace, arrFmt(format, args.toArray))
+
+
+  def isDebugEnabled: Boolean = includes(Debug)
+
+  def isDebugEnabled(marker: Marker): Boolean = isDebugEnabled
+
+  def debug(msg: String): Unit = log(Debug, msg, None)
+
+  def debug(format: String, arg: Any): Unit = log(Debug, fmt(format, arg))
+
+  def debug(format: String, arg1: Any, arg2: Any): Unit = log(Debug, fmt(format, arg1, arg2))
+
+  def debug(format: String, args: AnyRef*): Unit = log(Debug, arrFmt(format, args.toArray))
+
+  def debug(msg: String, err: Throwable): Unit = log(Debug, msg, Option(err))
+
+  def debug(marker: Marker, msg: String): Unit = log(marker, Debug, msg)
+
+  def debug(marker: Marker, msg: String, err: Throwable): Unit = log(marker, Debug, msg, err = Option(err))
+
+  def debug(marker: Marker, format: String, arg: Any): Unit =
+    log(marker, Debug, fmt(format, arg))
+
+  def debug(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+    log(marker, Debug, fmt(format, arg1, arg2))
+
+  def debug(marker: Marker, format: String, args: AnyRef*): Unit =
+    log(marker, Debug, arrFmt(format, args.toArray))
+
+
+  def isInfoEnabled: Boolean = includes(Info)
+
+  def isInfoEnabled(marker: Marker): Boolean = isInfoEnabled
+
+  def info(msg: String): Unit = log(Info, msg, None)
+
+  def info(format: String, arg: Any): Unit = log(Info, fmt(format, arg))
+
+  def info(format: String, arg1: Any, arg2: Any): Unit = log(Info, fmt(format, arg1, arg2))
+
+  def info(format: String, args: AnyRef*): Unit = log(Info, arrFmt(format, args.toArray))
+
+  def info(msg: String, err: Throwable): Unit = log(Info, msg, Option(err))
+
+  def info(marker: Marker, msg: String): Unit = log(marker, Info, msg)
+
+  def info(marker: Marker, msg: String, err: Throwable): Unit = log(marker, Info, msg, err = Option(err))
+
+  def info(marker: Marker, format: String, arg: Any): Unit =
+    log(marker, Info, fmt(format, arg))
+
+  def info(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+    log(marker, Info, fmt(format, arg1, arg2))
+
+  def info(marker: Marker, format: String, args: AnyRef*): Unit =
+    log(marker, Info, arrFmt(format, args.toArray))
+
+
+  def isWarnEnabled: Boolean = includes(Warn)
+
+  def isWarnEnabled(marker: Marker): Boolean = isWarnEnabled
+
+  def warn(msg: String): Unit = log(Warn, msg, None)
+
+  def warn(format: String, arg: Any): Unit = log(Warn, fmt(format, arg))
+
+  def warn(format: String, arg1: Any, arg2: Any): Unit = log(Warn, fmt(format, arg1, arg2))
+
+  def warn(format: String, args: AnyRef*): Unit = log(Warn, arrFmt(format, args.toArray))
+
+  def warn(msg: String, err: Throwable): Unit = log(Warn, msg, Option(err))
+
+  def warn(marker: Marker, msg: String): Unit = log(marker, Warn, msg)
+
+  def warn(marker: Marker, msg: String, err: Throwable): Unit = log(marker, Warn, msg, err = Option(err))
+
+  def warn(marker: Marker, format: String, arg: Any): Unit =
+    log(marker, Warn, fmt(format, arg))
+
+  def warn(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+    log(marker, Warn, fmt(format, arg1, arg2))
+
+  def warn(marker: Marker, format: String, args: AnyRef*): Unit =
+    log(marker, Warn, arrFmt(format, args.toArray))
+
+
+  def isErrorEnabled: Boolean = includes(Error)
+
+  def isErrorEnabled(marker: Marker): Boolean = isErrorEnabled
+
+  def error(msg: String): Unit = log(Error, msg, None)
+
+  def error(format: String, arg: Any): Unit = log(Error, fmt(format, arg))
+
+  def error(format: String, arg1: Any, arg2: Any): Unit = log(Error, fmt(format, arg1, arg2))
+
+  def error(format: String, args: AnyRef*): Unit = log(Error, arrFmt(format, args.toArray))
+
+  def error(msg: String, err: Throwable): Unit = log(Error, msg, Option(err))
+
+  def error(marker: Marker, msg: String): Unit = log(marker, Error, msg)
+
+  def error(marker: Marker, msg: String, err: Throwable): Unit = log(marker, Error, msg, err = Option(err))
+
+  def error(marker: Marker, format: String, arg: Any): Unit =
+    log(marker, Error, fmt(format, arg))
+
+  def error(marker: Marker, format: String, arg1: Any, arg2: Any): Unit =
+    log(marker, Error, fmt(format, arg1, arg2))
+
+  def error(marker: Marker, format: String, args: AnyRef*): Unit =
+    log(marker, Error, arrFmt(format, args.toArray))
+
+
+  private[this] final def includes(lvl: Level): Boolean = ScribeLogger(name).includes(lvl)
+
+  private[this] final def log(lvl: Level, msg: String, err: Option[Throwable]): Unit = {
+    import scribe.Loggable.StringLoggable
+
+    ScribeLogger(name).log(LogRecord(
+      level      = lvl,
+      value      = lvl.value,
+      message    = new LazyMessage(() => msg),
+      loggable   = StringLoggable,
+      throwable  = err,
+      fileName   = "",
+      className  = name,
+      methodName = None,
+      line       = None,
+      column     = None
+    ))
+  }
+
+  private[this] final def log(lvl: Level, tuple: FormattingTuple): Unit =
+    log(lvl, tuple.getMessage, Option(tuple.getThrowable))
+
+  private[this] final def log(
+    marker: Marker,
+    lvl: Level,
+    msg: String,
+    args: Array[AnyRef] = Array.emptyObjectArray,
+    err: Option[Throwable] = None
+  ): Unit = ScribeLogger(name).log(LogRecord(
+    level      = lvl,
+    value      = lvl.value,
+    message    = new LazyMessage(() => MarkedOutput(marker, msg, args)),
+    loggable   = MarkedOutput.NonBoxingLoggable,
+    throwable  = err,
+    fileName   = "",
+    className  = name,
+    methodName = None,
+    line       = None,
+    column     = None
+  ))
+
+  private[this] final def log(marker: Marker, lvl: Level, tuple: FormattingTuple): Unit =
+    log(marker, lvl, tuple.getMessage, tuple.getArgArray, Option(tuple.getThrowable))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,8 @@ object Dependencies {
 
     val logback = "1.2.3"
 
+    val scribe = "2.8.5"
+
     val monix = "3.2.2"
 
     val scalatest = "3.2.2"
@@ -66,6 +68,7 @@ object Dependencies {
   val catsEffect       = "org.typelevel"              %% "cats-effect"             % Version.catsEffect
   val monix            = "io.monix"                   %% "monix"                   % Version.monix
   val logback          = "ch.qos.logback"              % "logback-classic"         % Version.logback
+  val scribe           = "com.outr"                   %% "scribe"                  % Version.scribe
   val slf4j            = "org.slf4j"                   % "slf4j-api"               % Version.slf4j     % Provided
   val circeCore        = "io.circe"                   %% "circe-core"              % Version.circe
   val circeJava8       = "io.circe"                   %% "circe-java8"             % Version.circe


### PR DESCRIPTION
Tofu Logging integration for [Scribe](https://github.com/outr/scribe)

Basically just a copypasta from tofu logback layout and scribe-slf4j with minor changes, bringing Marker context and Args Array support. Made for fun.

Example of logback.xml rewrite into Scribe dsl:

```xml
<configuration>
  <appender name="rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">
    <file>logs/data.log</file>

    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
      <fileNamePattern>logs/data.%i.log</fileNamePattern>
      <minIndex>0</minIndex>
      <maxIndex>8</maxIndex>
    </rollingPolicy>

    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
      <maxFileSize>50MB</maxFileSize>
    </triggeringPolicy>

    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
      <charset>UTF-8</charset>
      <layout class="tofu.logging.ELKLayout"/>
    </encoder>
  </appender>

  <appender name="async" class="ch.qos.logback.classic.AsyncAppender">
    <queueSize>500</queueSize>
    <discardingThreshold>0</discardingThreshold>
    <appender-ref ref="rolling" />
  </appender>

  <logger name="io.netty" level="WARN"/>
  <logger name="com.twitter.finagle" level="WARN"/>

  <statusListener class="ch.qos.logback.core.status.NopStatusListener"/>

  <root level="debug">
    <appender-ref ref="async"/>
  </root>
</configuration>
```

```scala
import java.nio.file.Paths

import scribe.{Level, Logger}
import scribe.writer.FileWriter
import scribe.writer.file.{LogPath, FlushMode}
import scribe.handler.{AsynchronousLogHandler, Overflow}
import scribe.filter
import scribe.filter.{className, level}

import tofu.logging.ELKFormatter

Logger
    .root
    .clearHandlers()
    .clearModifiers()
    .withMinimumLevel(Level.Debug)
    .withHandler(AsynchronousLogHandler(
      maxBuffer = 500,
      overflow  = Overflow.Block,

      writer    = FileWriter()
        .io
        .withFlushMode(FlushMode.AsynchronousFlush(1.second))
        .path(LogPath.simple(
          directory = Paths.get("logs"),
          name = "data.log"
        ))
        .maxLogs(9)
        .maxSize(50_000_000),

      formatter = ELKFormatter.merge,

      modifiers = List(
        filter
          .select(
            className startsWith "com.twitter.finagle",
            className startsWith "io.netty"
          )
          .include(level >= Level.Warn)
      )
    ))
    .replace()
```