### PR TITLE
`Lift` usage eliminated from `evals` syntax.

### DIFF
--- a/streams/src/main/scala/tofu/syntax/streams/evals.scala
+++ b/streams/src/main/scala/tofu/syntax/streams/evals.scala
@@ -2,7 +2,6 @@ package tofu.syntax.streams
 
 import cats.syntax.functor._
 import cats.{Foldable, Functor}
-import tofu.lift.Lift
 import tofu.streams.Evals
 
 private[syntax] final class EvalsOps[F[_], G[_], A](private val fa: F[A]) extends AnyVal {
@@ -12,7 +11,7 @@ private[syntax] final class EvalsOps[F[_], G[_], A](private val fa: F[A]) extend
 }
 
 private[syntax] final class EvalPA[F[_]](private val __ : Boolean) extends AnyVal {
-  def apply[G[_], A](ga: G[A])(implicit ev: Lift[G, F]): F[A] = ev.lift(ga)
+  def apply[G[_], A](ga: G[A])(implicit ev: Evals[F, G]): F[A] = ev.eval(ga)
 }
 
 private[syntax] final class EvalsPA[F[_]](private val __ : Boolean) extends AnyVal {

--- a/streams/src/test/scala/tofu/streams/SyntaxTypeInferenceSuite.scala
+++ b/streams/src/test/scala/tofu/streams/SyntaxTypeInferenceSuite.scala
@@ -1,0 +1,14 @@
+package tofu.streams
+
+import cats.Applicative
+import cats.instances.list._
+import tofu.syntax.monadic._
+import tofu.syntax.streams.all._
+
+object SyntaxTypeInferenceSuite {
+
+  class EvalsInference[S[_]: Evals[*[_], F], F[_]: Applicative] {
+    def foo: S[Unit] = eval(().pure[F])
+    def bar: S[Unit] = evals(List((), (), ()).pure[F])
+  }
+}


### PR DESCRIPTION
Fixes error cases like this https://scastie.scala-lang.org/AekOpUbrRtaH4Fr5u9n4Fg